### PR TITLE
Add mysql support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "massive": "^5.1.3",
     "pg-promise": "^8.4.5",
+    "promise-mysql": "^3.3.1",
     "request": "^2.87.0",
     "request-promise-native": "^1.0.5"
   },
@@ -55,6 +56,7 @@
         "tsConfigFile": "tsconfig.json"
       }
     },
-    "testRegex": "(/src/.*(\\.|/)(test|spec))\\.(jsx?|tsx?)$"
+    "testRegex": "(/src/.*(\\.|/)(test|spec))\\.(jsx?|tsx?)$",
+    "testURL": "http://localhost"
   }
 }

--- a/src/demux/handlers/index.ts
+++ b/src/demux/handlers/index.ts
@@ -1,7 +1,9 @@
 import { AbstractActionHandler } from "./AbstractActionHandler"
 import { postgres } from "./postgres"
+import { mysql } from "./mysql"
 
 export const handlers = {
   AbstractActionHandler,
   postgres,
+  mysql
 }

--- a/src/demux/handlers/mysql/MysqlActionHandler.test.ts
+++ b/src/demux/handlers/mysql/MysqlActionHandler.test.ts
@@ -1,0 +1,122 @@
+import Docker from "dockerode"
+import mysql from "promise-mysql"
+import { MysqlActionHandler } from "./MysqlActionHandler"
+import { JsonActionReader } from "../../readers/testing/JsonActionReader"
+import blockchain from "./testHelpers/blockchain.json"
+import * as migrate from "./testHelpers/migrate"
+import * as dockerUtils from "./testHelpers/docker"
+import updaters from "./testHelpers/updaters"
+
+const docker = new Docker()
+const mysqlImageName = "mysql:5"
+const mysqlContainerName = "mysql-action-handler-test"
+const dbName = "demuxmysqltest"
+const dbUser = "root"
+const dbPass = "docker"
+let conn: any
+
+export function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+jest.setTimeout(30000)
+
+beforeAll(async () => {
+  await dockerUtils.pullImage(docker, mysqlImageName)
+  await dockerUtils.removeMysqlContainer(docker, mysqlContainerName)
+  await dockerUtils.startMysqlContainer(docker, mysqlImageName, mysqlContainerName, dbName, dbUser, dbPass)
+  conn = await mysql.createConnection({
+    host: 'localhost',
+    port: 3306,
+    user: dbUser,
+    password: dbPass,
+    multipleStatements: true
+  })
+  await migrate.up(conn)
+})
+
+afterAll(async () => {
+  await conn.end();
+  await dockerUtils.removeMysqlContainer(docker, mysqlContainerName)
+})
+
+describe("MysqlActionHandler", async () => {
+  beforeEach(async () => {
+    await migrate.reset(conn)
+  })
+
+  it("populates database correctly", async () => {
+    const actionReader = new JsonActionReader(blockchain)
+    const actionHandler = new MysqlActionHandler(updaters, [], conn)
+    const [block1, isRollback] = await actionReader.nextBlock()
+    await actionHandler.handleBlock(block1, isRollback, actionReader.isFirstBlock)
+    await wait(500)
+
+    let rows = await conn.query(`SELECT * FROM todo WHERE id=1`);
+    const groceries = rows[0];
+    expect(groceries).toEqual({
+      id: 1,
+      name: "Groceries",
+    })
+    rows = await conn.query(`SELECT * FROM todo WHERE id=2`);
+    const placesToVisit = rows[0];
+    expect(placesToVisit).toEqual({
+      id: 2,
+      name: "Places to Visit",
+    })
+
+    const [block2, isNotRollback] = await actionReader.nextBlock()
+    await actionHandler.handleBlock(block2, isNotRollback, actionReader.isFirstBlock)
+    await wait(500)
+
+    rows = await conn.query(`SELECT * FROM task WHERE name="cookies" LIMIT 1`);
+    const cookies = rows[0];
+    expect(cookies).toEqual({
+      id: 5,
+      name: "cookies",
+      completed: 0,
+      todo_id: 1,
+    })
+
+    rows = await conn.query(`SELECT * FROM task WHERE name="San Francisco" LIMIT 1`);
+    const sanFrancisco = rows[0];
+    expect(sanFrancisco).toEqual({
+      id: 9,
+      name: "San Francisco",
+      completed: 0,
+      todo_id: 2,
+    })
+
+    const [block3, alsoNotRollback] = await actionReader.nextBlock()
+    await actionHandler.handleBlock(block3, alsoNotRollback, actionReader.isFirstBlock)
+    await wait(500)
+
+    rows = await conn.query(`SELECT * FROM task WHERE name="milk" LIMIT 1`);
+    const milk = rows[0];
+    rows = await conn.query(`SELECT * FROM task WHERE name="cookies" LIMIT 1`);
+    const dippedCookies = rows[0];
+    expect(milk).toEqual({
+      id: 4,
+      name: "milk",
+      completed: 1,
+      todo_id: 1,
+    })
+    expect(dippedCookies).toEqual({
+      id: 5,
+      name: "cookies",
+      completed: 1,
+      todo_id: 1,
+    })
+
+    rows = await conn.query(`SELECT * FROM task WHERE completed=true AND todo_id=2 LIMIT 1`);
+    const hongKong = rows[0];
+    expect(hongKong).toEqual({
+      id: 6,
+      name: "Hong Kong",
+      completed: 1,
+      todo_id: 2,
+    })
+  })
+})

--- a/src/demux/handlers/mysql/MysqlActionHandler.ts
+++ b/src/demux/handlers/mysql/MysqlActionHandler.ts
@@ -1,0 +1,37 @@
+import { AbstractActionHandler } from "../AbstractActionHandler"
+import { Block, Effect, IndexState, Updater } from "../../../../index"
+
+/**
+ * Connects to a Mysql database using the NPM [mysql](https://github.com/mysqljs/mysql) package. This expects that
+ * the database is already migrated, including an `_index_state` table. Refer to the tests for more information.
+ */
+export class MysqlActionHandler extends AbstractActionHandler {
+  constructor(
+    protected updaters: Updater[],
+    protected effects: Effect[],
+    protected mysqlInstance: any,
+  ) {
+    super(updaters, effects)
+  }
+
+  protected async handleWithState(handle: (state: any, context?: any) => void): Promise<void> {
+    await handle(null, { conn: this.mysqlInstance });
+  }
+
+  protected async updateIndexState(state: any, block: Block, isReplay: boolean) {
+    this.mysqlInstance.query(`REPLACE INTO _index_state VALUES (0, ${block.blockNumber}, "${block.blockHash}", ${isReplay} )`);
+  }
+
+  protected async loadIndexState(): Promise<IndexState> {
+    const rows = await this.mysqlInstance.query(`SELECT * FROM _index_state WHERE id=0`)
+    if (rows.length == 0)
+      return { blockNumber: 0, blockHash: "" }
+    const blockNumber = rows[0].block_number;
+    const blockHash = rows[0].block_hash;
+    return { blockNumber, blockHash }
+  }
+
+  protected async rollbackTo(blockNumber: number) {
+    throw Error(`Cannot roll back to ${blockNumber}; \`rollbackTo\` not implemented.`)
+  }
+}

--- a/src/demux/handlers/mysql/MysqlActionHandler.ts
+++ b/src/demux/handlers/mysql/MysqlActionHandler.ts
@@ -18,7 +18,7 @@ export class MysqlActionHandler extends AbstractActionHandler {
     await handle(null, { conn: this.mysqlInstance });
   }
 
-  protected async updateIndexState(state: any, block: Block, isReplay: boolean) {
+  protected async updateIndexState(_state: any, block: Block, isReplay: boolean) {
     this.mysqlInstance.query(`REPLACE INTO _index_state VALUES (0, ${block.blockNumber}, "${block.blockHash}", ${isReplay} )`);
   }
 

--- a/src/demux/handlers/mysql/index.ts
+++ b/src/demux/handlers/mysql/index.ts
@@ -1,0 +1,3 @@
+import { MysqlActionHandler } from "./MysqlActionHandler"
+
+export const mysql = { MysqlActionHandler }

--- a/src/demux/handlers/mysql/testHelpers/blockchain.json
+++ b/src/demux/handlers/mysql/testHelpers/blockchain.json
@@ -1,0 +1,86 @@
+[
+  {
+    "blockNumber": 1,
+    "blockHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "actions": [
+      {
+        "type": "add_todo",
+        "payload": {
+          "todoName": "Groceries",
+          "id": 1
+        }
+      },
+      {
+        "type": "add_todo",
+        "payload": {
+          "todoName": "Places to Visit",
+          "id": 2
+        }
+      }
+    ]
+  },
+  {
+    "blockNumber": 2,
+    "blockHash": "0000000000000000000000000000000000000000000000000000000000000001",
+    "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
+    "actions": [
+      {
+        "type": "add_tasks",
+        "payload": {
+          "todoId": 1,
+          "tasks": [
+            "apples",
+            "bananas",
+            "pears",
+            "milk",
+            "cookies"
+          ]
+        }
+      },
+      {
+        "type": "add_tasks",
+        "payload": {
+          "todoId": 2,
+          "tasks": [
+            "Hong Kong",
+            "Sydney",
+            "London",
+            "San Francisco"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "blockNumber": 3,
+    "blockHash": "0000000000000000000000000000000000000000000000000000000000000002",
+    "previousBlockHash": "0000000000000000000000000000000000000000000000000000000000000001",
+    "actions": [
+      {
+        "type": "update_task",
+        "payload": {
+          "todoId": 1,
+          "taskName": "milk",
+          "completed": true
+        }
+      },
+      {
+        "type": "update_task",
+        "payload": {
+          "todoId": 1,
+          "taskName": "cookies",
+          "completed": true
+        }
+      },
+      {
+        "type": "update_task",
+        "payload": {
+          "todoId": 2,
+          "taskName": "Hong Kong",
+          "completed": true
+        }
+      }
+    ]
+  }
+]

--- a/src/demux/handlers/mysql/testHelpers/create.sql
+++ b/src/demux/handlers/mysql/testHelpers/create.sql
@@ -1,0 +1,24 @@
+CREATE DATABASE demuxmysqltest;
+USE demuxmysqltest;
+
+CREATE TABLE todo (
+  id int NOT NULL,
+  name text NOT NULL,
+  PRIMARY KEY(id)
+);
+
+CREATE TABLE task (
+  id int NOT NULL AUTO_INCREMENT,
+  todo_id int NOT NULL REFERENCES todos(id),
+  name text NOT NULL,
+  completed bool DEFAULT FALSE,
+  PRIMARY KEY(id)
+);
+
+CREATE TABLE _index_state (
+  id int NOT NULL,
+  block_number int NOT NULL,
+  block_hash text NOT NULL,
+  is_replay boolean NOT NULL,
+  PRIMARY KEY (id)
+);

--- a/src/demux/handlers/mysql/testHelpers/docker.ts
+++ b/src/demux/handlers/mysql/testHelpers/docker.ts
@@ -20,27 +20,6 @@ export async function pullImage(docker: any, imageName: string) {
 
 export async function waitForMysql(_container: Container, _dbPass: String) {
   await wait(20000);
-  //let connectionTries = 0
-  //while (connectionTries < 40) {
-  //  const exec = await container.exec({
-  //    Cmd: [`systemctl status mysql`],
-  //    AttachStdin: true,
-  //    AttachStdout: true,
-  //  })
-  //  const { output } = await exec.start({ hijack: true, stdin: true })
-  //  const data = await promisifyStream(output)
-  //  console.log(data);
-  //  const status = data.split(" - ")[1].trim()
-  //  if (status === "accepting connections") {
-  //    await wait(1000)
-  //    break
-  //  }
-  //  connectionTries += 1
-  //  await wait(500)
-  //}
-  //if (connectionTries === 30) {
-  //  throw Error("Too many tries to connect to database")
-  //}
 }
 
 export function wait(ms: number) {

--- a/src/demux/handlers/mysql/testHelpers/docker.ts
+++ b/src/demux/handlers/mysql/testHelpers/docker.ts
@@ -1,0 +1,84 @@
+import { Container } from "dockerode"
+import { Stream } from "stream"
+
+export function promisifyStream(stream: Stream): Promise<string> {
+  const data: Buffer[] = []
+  return new Promise((resolve, reject) => {
+    stream.on("data", (chunk) => data.push(chunk))
+    stream.on("end", () => {
+      const toReturn = Buffer.concat(data).toString()
+      resolve(toReturn)
+    })
+    stream.on("error", () => reject())
+  })
+}
+
+export async function pullImage(docker: any, imageName: string) {
+  const stream = await docker.pull(imageName)
+  await promisifyStream(stream)
+}
+
+export async function waitForMysql(container: Container, dbPass: String) {
+  await wait(20000);
+  //let connectionTries = 0
+  //while (connectionTries < 40) {
+  //  const exec = await container.exec({
+  //    Cmd: [`systemctl status mysql`],
+  //    AttachStdin: true,
+  //    AttachStdout: true,
+  //  })
+  //  const { output } = await exec.start({ hijack: true, stdin: true })
+  //  const data = await promisifyStream(output)
+  //  console.log(data);
+  //  const status = data.split(" - ")[1].trim()
+  //  if (status === "accepting connections") {
+  //    await wait(1000)
+  //    break
+  //  }
+  //  connectionTries += 1
+  //  await wait(500)
+  //}
+  //if (connectionTries === 30) {
+  //  throw Error("Too many tries to connect to database")
+  //}
+}
+
+export function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export async function startMysqlContainer(
+  docker: any,
+  imageName: string,
+  containerName: string,
+  dbName: string,
+  dbUser: string,
+  dbPass: string,
+) {
+  const container = await docker.createContainer({
+    Image: imageName,
+    name: containerName,
+    Tty: false,
+    PortBindings: { "3306/tcp": [{ HostPort: "3306" }] },
+    Env: [
+      `MYSQL_ROOT_PASSWORD=${dbPass}`,
+    ],
+  })
+  await container.start()
+  await waitForMysql(container, dbPass)
+}
+
+export async function removeMysqlContainer(docker: any, containerName: string) {
+  const containers = await docker.listContainers({ all: true })
+  for (const containerInfo of containers) {
+    if (containerInfo.Names[0] === `/${containerName}`) {
+      const container = docker.getContainer(containerInfo.Id)
+      if (containerInfo.State !== "exited") {
+        await container.stop()
+      }
+      await container.remove()
+    }
+  }
+}

--- a/src/demux/handlers/mysql/testHelpers/docker.ts
+++ b/src/demux/handlers/mysql/testHelpers/docker.ts
@@ -18,7 +18,7 @@ export async function pullImage(docker: any, imageName: string) {
   await promisifyStream(stream)
 }
 
-export async function waitForMysql(container: Container, dbPass: String) {
+export async function waitForMysql(_container: Container, _dbPass: String) {
   await wait(20000);
   //let connectionTries = 0
   //while (connectionTries < 40) {
@@ -53,8 +53,8 @@ export async function startMysqlContainer(
   docker: any,
   imageName: string,
   containerName: string,
-  dbName: string,
-  dbUser: string,
+  _dbName: string,
+  _dbUser: string,
   dbPass: string,
 ) {
   const container = await docker.createContainer({

--- a/src/demux/handlers/mysql/testHelpers/migrate.ts
+++ b/src/demux/handlers/mysql/testHelpers/migrate.ts
@@ -2,7 +2,11 @@ import * as path from "path"
 import fs from "fs"
 
 function loadQueryFile(file: string) {
-  var appDir = path.dirname(require.main.filename);
+  var appDir;
+  if (require.main)
+    appDir = path.dirname(require.main.filename);
+  else
+    appDir = "./"
   const fullPath = path.join(appDir, "testHelpers", file);
   return fs.readFileSync(fullPath, "utf-8");
 }

--- a/src/demux/handlers/mysql/testHelpers/migrate.ts
+++ b/src/demux/handlers/mysql/testHelpers/migrate.ts
@@ -1,0 +1,18 @@
+import * as path from "path"
+import fs from "fs"
+
+function loadQueryFile(file: string) {
+  var appDir = path.dirname(require.main.filename);
+  const fullPath = path.join(appDir, "testHelpers", file);
+  return fs.readFileSync(fullPath, "utf-8");
+}
+
+export async function up(conn: any) {
+  const create = loadQueryFile("create.sql");
+  await conn.query(create)
+}
+
+export async function reset(conn: any) {
+  const truncate = loadQueryFile("truncate.sql");
+  await conn.query(truncate);
+}

--- a/src/demux/handlers/mysql/testHelpers/truncate.sql
+++ b/src/demux/handlers/mysql/testHelpers/truncate.sql
@@ -1,0 +1,3 @@
+TRUNCATE TABLE task;
+TRUNCATE TABLE todo;
+TRUNCATE TABLE _index_state;

--- a/src/demux/handlers/mysql/testHelpers/updaters.ts
+++ b/src/demux/handlers/mysql/testHelpers/updaters.ts
@@ -1,0 +1,30 @@
+async function addTodo(state: null, payload: any, blockInfo: any, context: any) {
+  await context.conn.query(`INSERT INTO todo VALUES (${payload.id}, "${payload.todoName}")`);
+}
+
+async function addTasks(state: null, payload: any, blockInfo: any, context: any) {
+  for (const task of payload.tasks) {
+    await context.conn.query(`INSERT INTO task (todo_id, name) VALUES (${payload.todoId}, "${task}")`);
+  }
+}
+
+async function updateTask(state: null, payload: any, blockInfo: any, context: any) {
+  const rows = await context.conn.query(`SELECT * FROM task WHERE name="${payload.taskName}" LIMIT 1`);
+  const id = rows[0].id;
+  await context.conn.query(`UPDATE task SET completed=${payload.completed} WHERE id=${id}`);
+}
+
+export default [
+  {
+    actionType: "add_todo",
+    updater: addTodo,
+  },
+  {
+    actionType: "add_tasks",
+    updater: addTasks,
+  },
+  {
+    actionType: "update_task",
+    updater: updateTask,
+  },
+]

--- a/src/demux/handlers/mysql/testHelpers/updaters.ts
+++ b/src/demux/handlers/mysql/testHelpers/updaters.ts
@@ -1,14 +1,14 @@
-async function addTodo(state: null, payload: any, blockInfo: any, context: any) {
+async function addTodo(_state: null, payload: any, _blockInfo: any, context: any) {
   await context.conn.query(`INSERT INTO todo VALUES (${payload.id}, "${payload.todoName}")`);
 }
 
-async function addTasks(state: null, payload: any, blockInfo: any, context: any) {
+async function addTasks(_state: null, payload: any, _blockInfo: any, context: any) {
   for (const task of payload.tasks) {
     await context.conn.query(`INSERT INTO task (todo_id, name) VALUES (${payload.todoId}, "${task}")`);
   }
 }
 
-async function updateTask(state: null, payload: any, blockInfo: any, context: any) {
+async function updateTask(_state: null, payload: any, _blockInfo: any, context: any) {
   const rows = await context.conn.query(`SELECT * FROM task WHERE name="${payload.taskName}" LIMIT 1`);
   const id = rows[0].id;
   await context.conn.query(`UPDATE task SET completed=${payload.completed} WHERE id=${id}`);


### PR DESCRIPTION
Adding MySQL support through action handlers. The structure is very similar to the Postgres support. 

The example code is contained in a test using a standard MySQL docker container. The test has one major flaw, in the `waitForMysql` funciton where it simply waits 20s for the container to load instead of checking properly to see if MySQL is loaded. I'll look into fixing that. Actual usage shouldn't be affected by that since you will be connecting to an existing database.

NOTE: This is only tested with MySQL 5. Special configurations are required to get the mysql NPM package to work with MySQL 8. Likely simple to configure, but there is no sample code available in this PR for it.  