### PR TITLE
block-timestamp

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ export interface Block {
   blockHash: string
   blockNumber: number
   previousBlockHash: string
+  timestamp: Date
 }
 
 export interface IndexState {
@@ -20,6 +21,7 @@ export interface BlockInfo {
   blockHash: string
   blockNumber: number
   previousBlockHash: string
+  timestamp: Date
 }
 
 export interface Action {

--- a/src/demux/readers/eos/NodeosActionReader.test.ts
+++ b/src/demux/readers/eos/NodeosActionReader.test.ts
@@ -151,6 +151,7 @@ describe("NodeosActionReader", () => {
       blockHash: "000f4241873a9aef0daefd47d8821495b6f61c4d1c73544419eb0ddc22a9e906",
       blockNumber: 20,
       previousBlockHash: "000f42401b5636c3c1d88f31fe0e503654091fb822b0ffe21c7d35837fc9f3d8",
+      timestamp: new Date("2018-06-16T05:59:49.500")
     })
   })
 })

--- a/src/demux/readers/eos/NodeosBlock.ts
+++ b/src/demux/readers/eos/NodeosBlock.ts
@@ -11,6 +11,7 @@ export class NodeosBlock implements Block {
     this.blockNumber = rawBlock.block_num
     this.blockHash = rawBlock.id
     this.previousBlockHash = rawBlock.previous
+    this.timestamp = new Date(rawBlock.timestamp)
   }
 
   protected collectActionsFromBlock(rawBlock: any): EosAction[] {


### PR DESCRIPTION
Add support for block timestamps to BlockInfo. Many database entries use the `now()` command to save timestamps and the state can't be re-created without access to the block timestamp. 