### PR TITLE
Fix fork resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demux",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "author": {
     "name": "Julien Heller",
     "url": "https://block.one/"

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -28,7 +28,10 @@ export abstract class AbstractActionHandler {
     const { blockInfo } = block
 
     if (isRollback || (isReplay && isFirstBlock)) {
-      await this.rollbackTo(blockInfo.blockNumber - 1)
+      const rollbackCount = this.lastProcessedBlockNumber - blockInfo.blockNumber - 1
+      const rollbackBlockNumber = blockInfo.blockNumber - 1
+      console.info(`Rolling back ${rollbackCount} blocks to block ${rollbackBlockNumber}...`)
+      await this.rollbackTo(rollbackBlockNumber)
       await this.refreshIndexState()
     } else if (!this.lastProcessedBlockHash && this.lastProcessedBlockNumber === 0) {
       await this.refreshIndexState()

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -28,8 +28,8 @@ export abstract class AbstractActionHandler {
     const { blockInfo } = block
 
     if (isRollback || (isReplay && isFirstBlock)) {
-      const rollbackCount = this.lastProcessedBlockNumber - blockInfo.blockNumber - 1
       const rollbackBlockNumber = blockInfo.blockNumber - 1
+      const rollbackCount = this.lastProcessedBlockNumber - rollbackBlockNumber
       console.info(`Rolling back ${rollbackCount} blocks to block ${rollbackBlockNumber}...`)
       await this.rollbackTo(rollbackBlockNumber)
       await this.refreshIndexState()

--- a/src/AbstractActionReader.test.ts
+++ b/src/AbstractActionReader.test.ts
@@ -74,13 +74,16 @@ describe("Action Reader", () => {
     await actionReader.nextBlock()
     await actionReader.nextBlock()
     await actionReader.nextBlock()
+
     actionReader.blockchain = forked
     const [block, isRollback] = await actionReader.nextBlock()
     expect(isRollback).toBe(true)
     expect(block.blockInfo.blockHash).toBe("foo")
+
     const [block2, isRollback2] = await actionReader.nextBlock()
     expect(isRollback2).toBe(false)
     expect(block2.blockInfo.blockHash).toBe("wrench")
+
     const [block3, isRollback3] = await actionReader.nextBlock()
     expect(isRollback3).toBe(false)
     expect(block3.blockInfo.blockHash).toBe("madeit")

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -34,7 +34,7 @@ export abstract class AbstractActionReader {
 
   /**
    * Loads the next block with chainInterface after validating, updating all relevant state.
-   * If block fails validation, rollback will be called, and will update state to last block unseen.
+   * If block fails validation, resolveFork will be called, and will update state to last block unseen.
    */
   public async nextBlock(): Promise<[Block, boolean, boolean]> {
     let blockData = null
@@ -137,7 +137,7 @@ export abstract class AbstractActionReader {
 
   /**
    * Incrementally rolls back reader state one block at a time, comparing the blockHistory with
-   * newly fetched blocks. Rollback is finished when either the current block's previous hash
+   * newly fetched blocks. Fork resolution is finished when either the current block's previous hash
    * matches the previous block's hash, or when history is exhausted.
    *
    * @return {Promise<void>}
@@ -177,11 +177,11 @@ export abstract class AbstractActionReader {
   }
 
   /**
-   * When history is exhausted in rollback(), this is run to handle the situation. If left unimplemented,
+   * When history is exhausted in resolveFork(), this is run to handle the situation. If left unimplemented,
    * then only instantiate with `onlyIrreversible` set to true.
    */
   protected historyExhausted() {
-    console.info("Rollback history has been exhausted!")
-    throw Error("Rollback history has been exhausted, and no rollback exhaustion handling has been implemented.")
+    console.info("Fork resolution history has been exhausted!")
+    throw Error("Fork resolution history has been exhausted, and no history exhaustion handling has been implemented.")
   }
 }

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -73,10 +73,11 @@ export abstract class AbstractActionReader {
       } else {
         // Since the new block did not match our history, we can assume our history is wrong
         // and need to roll back
-        console.info("!! Fork detected !!")
-        console.info(`  expected: ${expectedHash}`)
-        console.info(`  received: ${actualHash}`)
-        await this.rollback()
+        console.info("!! FORK DETECTED !!")
+        console.info(`  MISMATCH:`)
+        console.info(`    ✓ NEW Block ${unvalidatedBlockData.blockInfo.blockNumber} previous: ${actualHash}`)
+        console.info(`    ✕ OLD Block ${this.currentBlockNumber} id:       ${expectedHash}`)
+        await this.resolveFork()
         isNewBlock = true
         isRollback = true // Signal action handler that we must roll back
         // Reset for safety, as new fork could have less blocks than the previous fork
@@ -141,46 +142,36 @@ export abstract class AbstractActionReader {
    *
    * @return {Promise<void>}
    */
-  protected async rollback() {
-    let blocksToRewind: number
-    // Rewind at least 1 block back
-    if (this.blockHistory.length > 0) {
-      // TODO:
-      // check and throw error if undefined
-      const block = this.blockHistory.pop()
-      if (block === undefined) {
-        throw Error ("block history should not have undefined entries.")
-      }
-      this.currentBlockData = await this.getBlock(block.blockInfo.blockNumber)
-      blocksToRewind = 1
+  protected async resolveFork() {
+    if (this.currentBlockData === null) {
+      throw Error("`currentBlockData` must not be null when initiating fork resolution.")
     }
 
     // Pop off blocks from cached block history and compare them with freshly fetched blocks
     while (this.blockHistory.length > 0) {
-      const [cachedPreviousBlockData] = this.blockHistory.slice(-1)
-      const previousBlockData = await this.getBlock(cachedPreviousBlockData.blockInfo.blockNumber)
-      const currentBlock = this.currentBlockData
-      if (currentBlock !== null) {
-        const { blockInfo: currentBlockInfo } = currentBlock
+      const [previousBlockData] = this.blockHistory.slice(-1)
+      console.info(`Refetching Block ${this.currentBlockData.blockInfo.blockNumber}...`)
+      this.currentBlockData = await this.getBlock(this.currentBlockData.blockInfo.blockNumber)
+      if (this.currentBlockData !== null) {
+        const { blockInfo: currentBlockInfo } = this.currentBlockData
         const { blockInfo: previousBlockInfo } = previousBlockData
         if (currentBlockInfo.previousBlockHash === previousBlockInfo.blockHash) {
-          console.info(`✓ BLOCK ${currentBlockInfo.blockNumber} MATCH:`)
-          console.info(`  expected: ${currentBlockInfo.previousBlockHash}`)
-          console.info(`  received: ${previousBlockInfo.blockHash}`)
-          console.info(`Rolling back ${blocksToRewind!} blocks to block ${currentBlockInfo.blockNumber}...`)
+          console.info("  MATCH:")
+          console.info(`    ✓ NEW Block ${currentBlockInfo.blockNumber} previous: ${currentBlockInfo.previousBlockHash}`) // tslint:disable-line
+          console.info(`    ✓ OLD Block ${previousBlockInfo.blockNumber} id:       ${previousBlockInfo.blockHash}`)
+          console.info("!! FORK RESOLVED !!")
           break
         }
-        console.info(`✕ BLOCK ${currentBlockInfo.blockNumber} MISMATCH:`)
-        console.info(`  expected: ${currentBlockInfo.previousBlockHash}`)
-        console.info(`  received: ${previousBlockInfo.blockHash}`)
+        console.info("  MISMATCH:")
+        console.info(`    ✓ NEW Block ${currentBlockInfo.blockNumber} previous: ${currentBlockInfo.previousBlockHash}`)
+        console.info(`    ✕ OLD Block ${previousBlockInfo.blockNumber} id:       ${previousBlockInfo.blockHash}`)
       }
 
       this.currentBlockData = previousBlockData
       this.blockHistory.pop()
-      blocksToRewind! += 1
     }
     if (this.blockHistory.length === 0) {
-      await this.rollbackExhausted()
+      await this.historyExhausted()
     }
     this.currentBlockNumber = this.blockHistory[this.blockHistory.length - 1].blockInfo.blockNumber + 1
   }
@@ -189,7 +180,7 @@ export abstract class AbstractActionReader {
    * When history is exhausted in rollback(), this is run to handle the situation. If left unimplemented,
    * then only instantiate with `onlyIrreversible` set to true.
    */
-  protected rollbackExhausted() {
+  protected historyExhausted() {
     console.info("Rollback history has been exhausted!")
     throw Error("Rollback history has been exhausted, and no rollback exhaustion handling has been implemented.")
   }

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -36,7 +36,7 @@ describe("BaseActionWatcher", () => {
 
     const updaters = [{
       actionType: "eosio.token::transfer",
-      updater: async (state, payload) => {
+      updater: async (state: any, payload: any) => {
         if (!state.totalTransferred) {
           state.totalTransferred = parseFloat(payload.data.quantity.amount)
         } else {


### PR DESCRIPTION
- Fix fork resolution bug that always rolled back 1 more extra block that was necessary
- Rename `rollback` => `resolveFork`, `rollbackExhausted` => `historyExhausted`
- Cleaned up console.info output
- Bumped major version (due to renaming of protected methods)