### PR TITLE
Add ability to match on flexible filters for updater / effects

### DIFF
--- a/examples/eos-transfers/effects.js
+++ b/examples/eos-transfers/effects.js
@@ -4,7 +4,7 @@ function logUpdate(state, payload, blockInfo, context) {
 
 const effects = [
   {
-    actionType: "eosio.token::transfer",
+    actionType: "*::transfer",
     effect: logUpdate,
   },
 ]

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -16,6 +16,18 @@ export abstract class AbstractActionHandler {
   ) {
   }
 
+
+  actionMatch(blockAction: string, filterAction: string) {
+    if (blockAction === filterAction) return true;
+    let [receiver, action] = blockAction.split("::")
+    let [_receiver, _action] = filterAction.split("::")
+    if ((_receiver === "*") || (_action === "*")) {
+      if ((receiver === _receiver) || (action === _action)) return true;
+    }
+    return false
+  }
+
+
   /**
    * Receive block, validate, and handle actions with updaters and effects
    */
@@ -98,7 +110,7 @@ export abstract class AbstractActionHandler {
     const { actions, blockInfo } = block
     for (const action of actions) {
       for (const updater of this.updaters) {
-        if (action.type === updater.actionType) {
+        if (this.actionMatch(action.type, updater.actionType)) {
           const { payload } = action
           await updater.updater(state, payload, blockInfo, context)
         }
@@ -117,7 +129,7 @@ export abstract class AbstractActionHandler {
     const { actions, blockInfo } = block
     for (const action of actions) {
       for (const effect of this.effects) {
-        if (action.type === effect.actionType) {
+        if (this.actionMatch(action.type, effect.actionType)) {
           const { payload } = action
           effect.effect(state, payload, blockInfo, context)
         }


### PR DESCRIPTION
The current filter matches on specific "receiver:action". For our use case we need to match on a wildcard of receiver, with a specific action.

This is a way to make the matching flexible by allowing "*::transfer" or "eosio.token::*". Don't usually write TS, tests pass for AbstractActionHandler (fail, for reader, which I didn't touch) but please make any suggestions if you feel this would be a good improvement to the library.

Thanks!