### PR TITLE
Implement Handler versions

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -26,25 +26,25 @@ describe("Action Handler", () => {
         versionName: "v1",
         updaters: [
           {
-            actionName: "eosio.token::transfer",
+            actionType: "eosio.token::transfer",
             apply: runUpdater,
           },
           {
-            actionName: "mycontract::upgrade",
+            actionType: "mycontract::upgrade",
             apply: runUpgradeUpdater,
           },
           {
-            actionName: "eosio.token::issue",
+            actionType: "eosio.token::issue",
             apply: notRunUpdater,
           },
         ],
         effects: [
           {
-            actionName: "eosio.token::transfer",
+            actionType: "eosio.token::transfer",
             run: runEffect,
           },
           {
-            actionName: "eosio.token::issue",
+            actionType: "eosio.token::issue",
             run: notRunEffect,
           },
         ],
@@ -53,21 +53,21 @@ describe("Action Handler", () => {
         versionName: "v2",
         updaters: [
           {
-            actionName: "eosio.token::transfer",
+            actionType: "eosio.token::transfer",
             apply: notRunUpdaterAfterUpgrade,
           },
           {
-            actionName: "eosio.token::issue",
+            actionType: "eosio.token::issue",
             apply: runUpdaterAfterUpgrade,
           },
         ],
         effects: [
           {
-            actionName: "eosio.token::transfer",
+            actionType: "eosio.token::transfer",
             run: notRunEffectAfterUpgrade,
           },
           {
-            actionName: "eosio.token::issue",
+            actionType: "eosio.token::issue",
             run: runEffectAfterUpgrade,
           },
         ],

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -115,17 +115,11 @@ export abstract class AbstractActionHandler {
           versionedActions.push([action, this.handlerVersionName])
           if (newVersion) {
             if (!this.handlerVersionMap.hasOwnProperty(newVersion)) {
-              console.warn(`Attempted to switch to handler version '${newVersion}', however this version ` +
-                           `does not exist. Handler will continue as version '${this.handlerVersionName}'`)
+              this.warnHandlerVersionNonexistent(newVersion)
               continue
             }
             console.info(`BLOCK ${blockInfo.blockNumber}: Updating Handler Version to '${newVersion}'`)
-            const remainingUpdaters = this.handlerVersionMap[this.handlerVersionName].updaters.length - updaterIndex - 1
-            if (remainingUpdaters) {
-              console.warn(`Handler Version was updated to version '${this.handlerVersionName}' while there ` +
-                           `were still ${remainingUpdaters} updaters left! These updaters will be skipped for the ` +
-                           `current action '${action.type}'.`)
-            }
+            this.warnSkippingUpdaters(updaterIndex, action.type)
             await this.updateHandlerVersionState(newVersion)
             this.handlerVersionName = newVersion
             break
@@ -201,6 +195,20 @@ export abstract class AbstractActionHandler {
       console.warn(`First Handler Version '${handlerVersions[0].versionName}' is not '${this.handlerVersionName}', ` +
                    `and there is also '${this.handlerVersionName}' present. Handler Version ` +
                    `'${this.handlerVersionName}' will be used, even though it is not first.`)
+    }
+  }
+
+  private warnHandlerVersionNonexistent(newVersion: string) {
+    console.warn(`Attempted to switch to handler version '${newVersion}', however this version ` +
+      `does not exist. Handler will continue as version '${this.handlerVersionName}'`)
+  }
+
+  private warnSkippingUpdaters(updaterIndex: number, actionType: string) {
+    const remainingUpdaters = this.handlerVersionMap[this.handlerVersionName].updaters.length - updaterIndex - 1
+    if (remainingUpdaters) {
+      console.warn(`Handler Version was updated to version '${this.handlerVersionName}' while there ` +
+        `were still ${remainingUpdaters} updaters left! These updaters will be skipped for the ` +
+        `current action '${actionType}'.`)
     }
   }
 

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -113,11 +113,9 @@ export abstract class AbstractActionHandler {
           const { payload } = action
           const newVersion = await updater.apply(state, payload, blockInfo, context)
           versionedActions.push([action, this.handlerVersionName])
-          if (newVersion) {
-            if (!this.handlerVersionMap.hasOwnProperty(newVersion)) {
-              this.warnHandlerVersionNonexistent(newVersion)
-              continue
-            }
+          if (newVersion && !this.handlerVersionMap.hasOwnProperty(newVersion)) {
+            this.warnHandlerVersionNonexistent(newVersion)
+          } else if (newVersion) {
             console.info(`BLOCK ${blockInfo.blockNumber}: Updating Handler Version to '${newVersion}'`)
             this.warnSkippingUpdaters(updaterIndex, action.type)
             await this.updateHandlerVersionState(newVersion)

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -9,7 +9,7 @@ import { Action, Block, HandlerVersion, IndexState } from "./interfaces"
 export abstract class AbstractActionHandler {
   protected lastProcessedBlockNumber: number = 0
   protected lastProcessedBlockHash: string = ""
-  private handlerVersionName: string = "v1"
+  protected handlerVersionName: string = "v1"
   private handlerVersionMap: { [key: string]: HandlerVersion } = {}
 
   constructor(
@@ -120,13 +120,14 @@ export abstract class AbstractActionHandler {
               continue
             }
             console.info(`BLOCK ${blockInfo.blockNumber}: Updating Handler Version to '${newVersion}'`)
-            await this.updateHandlerVersionState(newVersion)
-            this.handlerVersionName = newVersion
-            const remainingUpdaters = updaterIndex - this.handlerVersionMap[this.handlerVersionName].updaters.length - 1
+            const remainingUpdaters = this.handlerVersionMap[this.handlerVersionName].updaters.length - updaterIndex - 1
             if (remainingUpdaters) {
               console.warn(`Handler Version was updated to version '${this.handlerVersionName}' while there ` +
-                           `were still ${remainingUpdaters} updaters left! These updaters will be skipped.`)
+                           `were still ${remainingUpdaters} updaters left! These updaters will be skipped for the ` +
+                           `current action '${action.type}'.`)
             }
+            await this.updateHandlerVersionState(newVersion)
+            this.handlerVersionName = newVersion
             break
           }
         }

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -109,7 +109,7 @@ export abstract class AbstractActionHandler {
       let updaterIndex = -1
       for (const updater of this.handlerVersionMap[this.handlerVersionName].updaters) {
         updaterIndex += 1
-        if (action.type === updater.actionName) {
+        if (action.type === updater.actionType) {
           const { payload } = action
           const newVersion = await updater.apply(state, payload, blockInfo, context)
           versionedActions.push([action, this.handlerVersionName])
@@ -146,7 +146,7 @@ export abstract class AbstractActionHandler {
   ) {
     for (const [action, handlerVersionName] of versionedActions) {
       for (const effect of this.handlerVersionMap[handlerVersionName].effects) {
-        if (action.type === effect.actionName) {
+        if (action.type === effect.actionType) {
           const { payload } = action
           effect.run(payload, block, context)
         }

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -1,4 +1,4 @@
-import { Block, Effect, IndexState, Updater } from "./interfaces"
+import { Action, Block, BlockInfo, HandlerVersion, IndexState, } from "./interfaces"
 
 /**
  * Takes `block`s output from implementations of `AbstractActionReader` and processes their actions through
@@ -7,13 +7,15 @@ import { Block, Effect, IndexState, Updater } from "./interfaces"
  * `loadIndexState`.
  */
 export abstract class AbstractActionHandler {
-  protected lastProcessedBlockNumber: number = 0
-  protected lastProcessedBlockHash: string = ""
+  private lastProcessedBlockNumber: number = 0
+  private lastProcessedBlockHash: string = ""
+  private handlerVersionName: string = "v1"
+  private handlerVersionMap: { [key: string]: HandlerVersion } = {}
 
   constructor(
-    protected updaters: Updater[],
-    protected effects: Effect[],
+    handlerVersions: HandlerVersion[],
   ) {
+    this.initHandlerVersions(handlerVersions)
   }
 
   /**
@@ -33,8 +35,10 @@ export abstract class AbstractActionHandler {
       console.info(`Rolling back ${rollbackCount} blocks to block ${rollbackBlockNumber}...`)
       await this.rollbackTo(rollbackBlockNumber)
       await this.refreshIndexState()
-    } else if (!this.lastProcessedBlockHash && this.lastProcessedBlockNumber === 0) {
+      await this.refreshHandlerVersionState()
+    } else if (this.lastProcessedBlockNumber === 0 && this.lastProcessedBlockHash === "") {
       await this.refreshIndexState()
+      await this.refreshHandlerVersionState()
     }
 
     const nextBlockNeeded = this.lastProcessedBlockNumber + 1
@@ -81,6 +85,10 @@ export abstract class AbstractActionHandler {
    */
   protected abstract async loadIndexState(): Promise<IndexState>
 
+  protected abstract async updateHandlerVersionState(handlerVersionName: string): Promise<void>
+
+  protected abstract async loadHandlerVersionState(): Promise<string>
+
   /**
    * Calls handleActions with the appropriate state passed by calling the `handle` parameter function.
    * Optionally, pass in a `context` object as a second parameter.
@@ -90,36 +98,56 @@ export abstract class AbstractActionHandler {
   /**
    * Process actions against deterministically accumulating updater functions.
    */
-  protected async runUpdaters(
+  protected async applyUpdaters(
     state: any,
     block: Block,
     context: any,
-  ): Promise<void> {
+  ): Promise<Array<[Action, string]>> {
+    const versionedActions = [] as Array<[Action, string]>
     const { actions, blockInfo } = block
     for (const action of actions) {
-      for (const updater of this.updaters) {
+      let updaterIndex = -1
+      for (const updater of this.handlerVersionMap[this.handlerVersionName].updaters) {
+        updaterIndex += 1
         if (action.type === updater.actionType) {
           const { payload } = action
-          await updater.updater(state, payload, blockInfo, context)
+          const newVersion = await updater.apply(state, payload, blockInfo, context)
+          versionedActions.push([action, this.handlerVersionName])
+          if (newVersion) {
+            if (!this.handlerVersionMap.hasOwnProperty(newVersion)) {
+              console.warn(`Attempted to switch to handler version '${newVersion}', however this version ` +
+                           `does not exist. Handler will continue as version '${this.handlerVersionName}'`)
+              continue
+            }
+            console.info(`BLOCK ${blockInfo.blockNumber}: Updating Handler Version to '${newVersion}'`)
+            await this.updateHandlerVersionState(newVersion)
+            this.handlerVersionName = newVersion
+            const remainingUpdaters = updaterIndex - this.handlerVersionMap[this.handlerVersionName].updaters.length - 1
+            if (remainingUpdaters) {
+              console.warn(`Handler Version was updated to version '${this.handlerVersionName}' while there ` +
+                           `were still ${remainingUpdaters} updaters left! These updaters will be skipped.`)
+            }
+            break
+          }
         }
       }
     }
+    return versionedActions
   }
 
   /**
    * Process actions against asynchronous side effects.
    */
   protected runEffects(
-    state: any,
-    block: Block,
+    versionedActions: Array<[Action, string]>,
+    blockInfo: BlockInfo,
     context: any,
   ): void {
-    const { actions, blockInfo } = block
-    for (const action of actions) {
-      for (const effect of this.effects) {
+    for (const [action, handlerVersionName] of versionedActions) {
+      for (const effect of this.handlerVersionMap[handlerVersionName].effects) {
         if (action.type === effect.actionType) {
           const { payload } = action
-          effect.effect(state, payload, blockInfo, context)
+          effect.run(payload, blockInfo, context)
         }
       }
     }
@@ -133,7 +161,7 @@ export abstract class AbstractActionHandler {
   protected abstract async rollbackTo(blockNumber: number): Promise<void>
 
   /**
-   * Calls `runUpdaters` and `runEffects` on the given actions
+   * Calls `applyUpdaters` and `runEffects` on the given actions
    */
   protected async handleActions(
     state: any,
@@ -143,9 +171,9 @@ export abstract class AbstractActionHandler {
   ): Promise<void> {
     const { blockInfo } = block
 
-    await this.runUpdaters(state, block, context)
+    const versionedActions = await this.applyUpdaters(state, block, context)
     if (!isReplay) {
-      this.runEffects(state, block, context)
+      this.runEffects(versionedActions, blockInfo, context)
     }
 
     await this.updateIndexState(state, block, isReplay, context)
@@ -153,9 +181,35 @@ export abstract class AbstractActionHandler {
     this.lastProcessedBlockHash = blockInfo.blockHash
   }
 
+  private initHandlerVersions(handlerVersions: HandlerVersion[]) {
+    if (handlerVersions.length === 0) {
+      throw new Error("Must have at least one handler version.")
+    }
+    for (const handlerVersion of handlerVersions) {
+      if (this.handlerVersionMap.hasOwnProperty(handlerVersion.name)) {
+        throw new Error(`Handler version name '${handlerVersion.name}' already exists. ` +
+                        "Handler versions must have unique names.")
+      }
+      this.handlerVersionMap[handlerVersion.name] = handlerVersion
+    }
+    if (!this.handlerVersionMap.hasOwnProperty(this.handlerVersionName)) {
+      console.warn(`No Handler Version found with name '${this.handlerVersionName}': starting with ` +
+                   `'${handlerVersions[0].name}' instead.`)
+      this.handlerVersionName = handlerVersions[0].name
+    } else if (handlerVersions[0].name !== "v1") {
+      console.warn(`First Handler Version '${handlerVersions[0].name}' is not '${this.handlerVersionName}', ` +
+                   `and there is also '${this.handlerVersionName}' present. Handler Version ` +
+                   `'${this.handlerVersionName}' will be used, even though it is not first.`)
+    }
+  }
+
   private async refreshIndexState() {
     const { blockNumber, blockHash } = await this.loadIndexState()
     this.lastProcessedBlockNumber = blockNumber
     this.lastProcessedBlockHash = blockHash
+  }
+
+  private async refreshHandlerVersionState() {
+    this.handlerVersionName = await this.loadHandlerVersionState()
   }
 }

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -35,8 +35,8 @@ describe("BaseActionWatcher", () => {
     actionReaderNegative.blockchain = blockchain
 
     const updaters = [{
-      actionType: "eosio.token::transfer",
-      updater: async (state: any, payload: any) => {
+      actionName: "eosio.token::transfer",
+      apply: async (state: any, payload: any) => {
         if (!state.totalTransferred) {
           state.totalTransferred = parseFloat(payload.data.quantity.amount)
         } else {
@@ -45,13 +45,13 @@ describe("BaseActionWatcher", () => {
       },
     }]
     const effects = [{
-      actionType: "eosio.token::transfer",
-      effect: runEffect,
+      actionName: "eosio.token::transfer",
+      run: runEffect,
     }]
 
-    actionHandler = new TestActionHandler(updaters, effects)
-    actionHandlerStartAt3 = new TestActionHandler(updaters, effects)
-    actionHandlerNegative = new TestActionHandler(updaters, effects)
+    actionHandler = new TestActionHandler([{ versionName: "v1", updaters, effects }])
+    actionHandlerStartAt3 = new TestActionHandler([{ versionName: "v1", updaters, effects }])
+    actionHandlerNegative = new TestActionHandler([{ versionName: "v1", updaters, effects }])
 
     actionWatcher = new TestActionWatcher(actionReader, actionHandler, 500)
     actionWatcherStartAt3 = new TestActionWatcher(actionReaderStartAt3, actionHandlerStartAt3, 500)

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -35,7 +35,7 @@ describe("BaseActionWatcher", () => {
     actionReaderNegative.blockchain = blockchain
 
     const updaters = [{
-      actionName: "eosio.token::transfer",
+      actionType: "eosio.token::transfer",
       apply: async (state: any, payload: any) => {
         if (!state.totalTransferred) {
           state.totalTransferred = parseFloat(payload.data.quantity.amount)
@@ -45,7 +45,7 @@ describe("BaseActionWatcher", () => {
       },
     }]
     const effects = [{
-      actionName: "eosio.token::transfer",
+      actionType: "eosio.token::transfer",
       run: runEffect,
     }]
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,8 +23,7 @@ export interface Action {
 }
 
 export interface ActionListener {
-  name: string
-  actionType: string
+  actionName: string
 }
 
 export type ActionCallback = (
@@ -36,7 +35,7 @@ export type ActionCallback = (
 
 export type StatelessActionCallback = (
   payload: any,
-  blockInfo: BlockInfo,
+  block: Block,
   context: any,
 ) => void | Promise<void>
 
@@ -51,7 +50,7 @@ export interface Effect extends ActionListener {
 }
 
 export interface HandlerVersion {
-  name: string
+  versionName: string
   updaters: Updater[]
   effects: Effect[]
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,7 +23,7 @@ export interface Action {
 }
 
 export interface ActionListener {
-  actionName: string
+  actionType: string
 }
 
 export type ActionCallback = (

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,6 +6,8 @@ export interface Block {
 export interface IndexState {
   blockNumber: number
   blockHash: string
+  handlerVersion: string
+  isReplay: boolean
 }
 
 export interface BlockInfo {
@@ -20,12 +22,36 @@ export interface Action {
   payload: any
 }
 
-export interface Updater {
+export interface ActionListener {
+  name: string
   actionType: string
-  updater: (state: any, payload: any, blockInfo: BlockInfo, context: any) => void
 }
 
-export interface Effect {
-  actionType: string
-  effect: (state: any, payload: any, blockInfo: BlockInfo, context: any) => void
+export type ActionCallback = (
+  state: any,
+  payload: any,
+  blockInfo: BlockInfo,
+  context: any,
+) => void | string | Promise<void> | Promise<string>
+
+export type StatelessActionCallback = (
+  payload: any,
+  blockInfo: BlockInfo,
+  context: any,
+) => void | Promise<void>
+
+export interface Updater extends ActionListener {
+  apply: ActionCallback
+  revert?: ActionCallback
+}
+
+export interface Effect extends ActionListener {
+  run: StatelessActionCallback
+  onRollback?: StatelessActionCallback
+}
+
+export interface HandlerVersion {
+  name: string
+  updaters: Updater[]
+  effects: Effect[]
 }

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -1,9 +1,9 @@
 import { AbstractActionHandler } from "../AbstractActionHandler"
-import { Block, IndexState } from "../interfaces"
+import { Action, Block, IndexState } from "../interfaces"
 
 export class TestActionHandler extends AbstractActionHandler {
   public state: any = {
-    indexState: { blockNumber: 0, blockHash: "" },
+    indexState: { blockNumber: 0, blockHash: "", isReplay: false, handlerVersion: "v1" },
   }
 
   // tslint:disable-next-line
@@ -24,12 +24,16 @@ export class TestActionHandler extends AbstractActionHandler {
     this.lastProcessedBlockNumber = num
   }
 
-  public async _runUpdaters(state: any, block: Block, context: any) {
-    await this.runUpdaters(state, block, context)
+  public async _applyUpdaters(state: any, block: Block, context: any): Promise<Array<[Action, string]>> {
+    return this.applyUpdaters(state, block, context)
   }
 
-  public _runEffects(state: any, block: Block, context: any) {
-    this.runEffects(state, block, context)
+  public _runEffects(
+    versionedActions: Array<[Action, string]>,
+    block: Block,
+    context: any,
+  ) {
+    this.runEffects(versionedActions, block, context)
   }
 
   protected async loadIndexState(): Promise<IndexState> {
@@ -39,5 +43,13 @@ export class TestActionHandler extends AbstractActionHandler {
   protected async updateIndexState(state: any, block: Block) {
     const { blockNumber, blockHash } = block.blockInfo
     state.indexState = { blockNumber, blockHash }
+  }
+
+  protected async loadHandlerVersionState(): Promise<string> {
+    return this.state.indexState.handlerVersion
+  }
+
+  protected async updateHandlerVersionState(handlerVersionName: string) {
+    this.state.indexState.handlerVersion = handlerVersionName
   }
 }

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -6,6 +6,8 @@ export class TestActionHandler extends AbstractActionHandler {
     indexState: { blockNumber: 0, blockHash: "", isReplay: false, handlerVersion: "v1" },
   }
 
+  get _handlerVersionName() { return this.handlerVersionName }
+
   // tslint:disable-next-line
   public async handleWithState(handle: (state: any) => void) {
     await handle(this.state)

--- a/src/testHelpers/blockchains.ts
+++ b/src/testHelpers/blockchains.ts
@@ -166,4 +166,59 @@ export default {
       actions: [],
     },
   ],
+  upgradeHandler: [
+    {
+      blockInfo: {
+        blockHash: "0000000000000000000000000000000000000000000000000000000000000001",
+        blockNumber: 1,
+        previousBlockHash: "",
+        timestamp: new Date("2018-06-06T11:53:37.500"),
+      },
+      actions: [
+        {
+          payload: {
+            account: "eosio.token",
+            actionIndex: 0,
+            authorization: [],
+            data: {
+              quantity: {
+                amount: "42.00000",
+                symbol: "EOS",
+              },
+            },
+            name: "transfer",
+            transactionId: "1",
+          },
+          type: "eosio.token::transfer",
+        },
+        {
+          payload: {
+            account: "mycontract",
+            actionIndex: 1,
+            authorization: [],
+            data: { versionName: "v2" },
+            name: "upgrade",
+            transactionId: "1",
+          },
+          type: "mycontract::upgrade",
+        },
+        {
+          payload: {
+            account: "eosio.token",
+            actionIndex: 2,
+            authorization: [],
+            data: {
+              quantity: {
+                amount: "42.00000",
+                symbol: "EOS",
+              },
+            },
+            name: "issue",
+            transactionId: "1",
+          },
+          type: "eosio.token::issue",
+        },
+      ],
+    },
+  ],
 }


### PR DESCRIPTION
This PR:

- Implements multiple, versioned sets of updaters/effects (called `HandlerVersion`s)
- Implements the ability to switch between `HandlerVersion`s by returning a value from any Updater
- Warns user for various misuse scenarios
- Refactor interfaces
- Update some naming conventions

Would like constructive feedback on the API, open to improvements!