### PR TITLE
Combine handler version state with index state

### DIFF
--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -64,6 +64,8 @@ describe("BaseActionWatcher", () => {
       indexState: {
         blockHash: "0000000000000000000000000000000000000000000000000000000000000003",
         blockNumber: 4,
+        handlerVersionName: "v1",
+        isReplay: false,
       },
       totalTransferred: 66,
     })
@@ -76,6 +78,8 @@ describe("BaseActionWatcher", () => {
       indexState: {
         blockHash: "0000000000000000000000000000000000000000000000000000000000000003",
         blockNumber: 4,
+        handlerVersionName: "v1",
+        isReplay: false,
       },
       totalTransferred: 24,
     })
@@ -88,6 +92,8 @@ describe("BaseActionWatcher", () => {
       indexState: {
         blockHash: "0000000000000000000000000000000000000000000000000000000000000003",
         blockNumber: 4,
+        handlerVersionName: "v1",
+        isReplay: false,
       },
       totalTransferred: 24,
     })
@@ -125,6 +131,8 @@ describe("BaseActionWatcher", () => {
       indexState: {
         blockHash: "newblock",
         blockNumber: 5,
+        handlerVersionName: "v1",
+        isReplay: false,
       },
       totalTransferred: 189,
     })

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -6,7 +6,7 @@ export interface Block {
 export interface IndexState {
   blockNumber: number
   blockHash: string
-  handlerVersion: string
+  handlerVersionName: string
   isReplay: boolean
 }
 

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -3,7 +3,7 @@ import { Action, Block, IndexState } from "../interfaces"
 
 export class TestActionHandler extends AbstractActionHandler {
   public state: any = {
-    indexState: { blockNumber: 0, blockHash: "", isReplay: false, handlerVersion: "v1" },
+    indexState: { blockNumber: 0, blockHash: "", isReplay: false, handlerVersionName: "v1" },
   }
 
   get _handlerVersionName() { return this.handlerVersionName }
@@ -26,8 +26,13 @@ export class TestActionHandler extends AbstractActionHandler {
     this.lastProcessedBlockNumber = num
   }
 
-  public async _applyUpdaters(state: any, block: Block, context: any): Promise<Array<[Action, string]>> {
-    return this.applyUpdaters(state, block, context)
+  public async _applyUpdaters(
+    state: any,
+    block: Block,
+    isReplay: boolean,
+    context: any,
+  ): Promise<Array<[Action, string]>> {
+    return this.applyUpdaters(state, block, isReplay, context)
   }
 
   public _runEffects(
@@ -42,16 +47,8 @@ export class TestActionHandler extends AbstractActionHandler {
     return this.state.indexState
   }
 
-  protected async updateIndexState(state: any, block: Block) {
+  protected async updateIndexState(state: any, block: Block, isReplay: boolean, handlerVersionName: string) {
     const { blockNumber, blockHash } = block.blockInfo
-    state.indexState = { blockNumber, blockHash }
-  }
-
-  protected async loadHandlerVersionState(): Promise<string> {
-    return this.state.indexState.handlerVersion
-  }
-
-  protected async updateHandlerVersionState(handlerVersionName: string) {
-    this.state.indexState.handlerVersion = handlerVersionName
+    state.indexState = { blockNumber, blockHash, isReplay, handlerVersionName }
   }
 }


### PR DESCRIPTION
While implementing the corresponding changes to demux-js-postgres, I realized that this could be simplified. Everything is now saved/loaded from `indexState`, including the current `handlerVersionName`.