### PR TITLE
private log -> protected log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demux",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "author": {
     "name": "Julien Heller",
     "url": "https://block.one/"

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -12,8 +12,8 @@ export abstract class AbstractActionHandler {
   protected lastProcessedBlockNumber: number = 0
   protected lastProcessedBlockHash: string = ""
   protected handlerVersionName: string = "v1"
+  protected log: Logger
   private handlerVersionMap: { [key: string]: HandlerVersion } = {}
-  private log: Logger
 
   /**
    * @param handlerVersions  An array of `HandlerVersion`s that are to be used when processing blocks. The default

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -11,8 +11,8 @@ export abstract class AbstractActionReader {
   protected currentBlockData: Block | null = null
   protected lastIrreversibleBlockNumber: number = 0
   protected blockHistory: Block[] = []
+  protected log: Logger
   private isFirstRun: boolean = true
-  private log: Logger
 
  /**
   * @param startAtBlock      For positive values, this sets the first block that this will start at. For negative


### PR DESCRIPTION
Makes the `log` property protected instead of private, so it may be used by subclasses.

Also bumps to version 3.1.3 to prep for release.