### PR TITLE
Move Action Reader arguments into config object, various refactoring

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -112,23 +112,36 @@ describe("Action Handler", () => {
       blockNumber: 3,
       blockHash: "000f42401b5636c3c1d88f31fe0e503654091fb822b0ffe21c7d35837fc9f3d8",
     }
-    const [needToSeek, seekBlockNum] = await actionHandler.handleBlock(blockchain[0], false, true)
-    expect(needToSeek).toBe(true)
+    const blockMeta = {
+      isRollback: false,
+      isFirstBlock: true,
+      isNewBlock: true,
+    }
+    const seekBlockNum = await actionHandler.handleBlock(blockchain[0], blockMeta, false)
     expect(seekBlockNum).toBe(4)
   })
 
   it("seeks to the next block needed when block number doesn't match last processed block", async () => {
     actionHandler.setLastProcessedBlockNumber(2)
-    const [needToSeek, seekBlockNum] = await actionHandler.handleBlock(blockchain[3], false, false)
-    expect(needToSeek).toBe(true)
+    const blockMeta = {
+      isRollback: false,
+      isFirstBlock: false,
+      isNewBlock: true,
+    }
+    const seekBlockNum = await actionHandler.handleBlock(blockchain[3], blockMeta, false)
     expect(seekBlockNum).toBe(3)
   })
 
   it("throws error if previous block hash and last processed don't match up", async () => {
     actionHandler.setLastProcessedBlockNumber(3)
     actionHandler.setLastProcessedBlockHash("asdfasdfasdf")
+    const blockMeta = {
+      isRollback: false,
+      isFirstBlock: false,
+      isNewBlock: true,
+    }
     const expectedError = new Error("Block hashes do not match; block not part of current chain.")
-    await expect(actionHandler.handleBlock(blockchain[3], false, false)).rejects.toEqual(expectedError)
+    await expect(actionHandler.handleBlock(blockchain[3], blockMeta, false)).rejects.toEqual(expectedError)
   })
 
   it("upgrades the action handler correctly", async () => {

--- a/src/AbstractActionReader.test.ts
+++ b/src/AbstractActionReader.test.ts
@@ -11,8 +11,8 @@ describe("Action Reader", () => {
 
   beforeEach(() => {
     actionReader = new TestActionReader()
-    actionReaderStartAt3 = new TestActionReader(3)
-    actionReaderNegative = new TestActionReader(-1)
+    actionReaderStartAt3 = new TestActionReader({ startAtBlock: 3 })
+    actionReaderNegative = new TestActionReader({ startAtBlock: -1 })
 
     blockchain = JSON.parse(JSON.stringify(blockchains.blockchain))
     forked = JSON.parse(JSON.stringify(blockchains.forked))
@@ -48,9 +48,9 @@ describe("Action Reader", () => {
     await actionReader.nextBlock()
     await actionReader.nextBlock()
     await actionReader.seekToBlock(1)
-    const [block] = await actionReader.nextBlock()
+    const [block, blockMeta] = await actionReader.nextBlock()
     expect(block.blockInfo.blockNumber).toBe(1)
-    expect(actionReader.isFirstBlock).toBe(true)
+    expect(blockMeta.isFirstBlock).toBe(true)
   })
 
   it("seeks to non-first block", async () => {
@@ -76,16 +76,16 @@ describe("Action Reader", () => {
     await actionReader.nextBlock()
 
     actionReader.blockchain = forked
-    const [block, isRollback] = await actionReader.nextBlock()
-    expect(isRollback).toBe(true)
+    const [block, blockMeta] = await actionReader.nextBlock()
+    expect(blockMeta.isRollback).toBe(true)
     expect(block.blockInfo.blockHash).toBe("foo")
 
-    const [block2, isRollback2] = await actionReader.nextBlock()
-    expect(isRollback2).toBe(false)
+    const [block2, blockMeta2] = await actionReader.nextBlock()
+    expect(blockMeta2.isRollback).toBe(false)
     expect(block2.blockInfo.blockHash).toBe("wrench")
 
-    const [block3, isRollback3] = await actionReader.nextBlock()
-    expect(isRollback3).toBe(false)
+    const [block3, blockMeta3] = await actionReader.nextBlock()
+    expect(blockMeta3.isRollback).toBe(false)
     expect(block3.blockInfo.blockHash).toBe("madeit")
   })
 
@@ -94,7 +94,7 @@ describe("Action Reader", () => {
     await actionReader.nextBlock()
     await actionReader.nextBlock()
     await actionReader.nextBlock()
-    const isNewBlock = (await actionReader.nextBlock())[2]
-    expect(isNewBlock).toBe(false)
+    const blockMeta = (await actionReader.nextBlock())[1]
+    expect(blockMeta.isNewBlock).toBe(false)
   })
 })

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -17,17 +17,17 @@ export abstract class AbstractActionReader {
   protected log: Logger
   private isFirstRun: boolean = true
 
-  constructor(config?: ActionReaderConfig) {
-    const configWithDefaults = {
+  constructor(options: ActionReaderConfig = {}) {
+    const optionsWithDefaults = {
       startAtBlock: 1,
       onlyIrreversible: false,
       maxHistoryLength: 600,
-      ...(config || {}),
+      ...options,
     }
-    this.startAtBlock = configWithDefaults.startAtBlock
-    this.currentBlockNumber = configWithDefaults.startAtBlock - 1
-    this.onlyIrreversible = configWithDefaults.onlyIrreversible
-    this.maxHistoryLength = configWithDefaults.maxHistoryLength
+    this.startAtBlock = optionsWithDefaults.startAtBlock
+    this.currentBlockNumber = optionsWithDefaults.startAtBlock - 1
+    this.onlyIrreversible = optionsWithDefaults.onlyIrreversible
+    this.maxHistoryLength = optionsWithDefaults.maxHistoryLength
 
     this.log = Logger.createLogger({ name: "demux" })
   }

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -26,8 +26,8 @@ describe("BaseActionWatcher", () => {
 
   beforeEach(() => {
     actionReader = new TestActionReader()
-    actionReaderStartAt3 = new TestActionReader(3)
-    actionReaderNegative = new TestActionReader(-1)
+    actionReaderStartAt3 = new TestActionReader({ startAtBlock: 3 })
+    actionReaderNegative = new TestActionReader({ startAtBlock: -1 })
 
     blockchain = JSON.parse(JSON.stringify(blockchains.blockchain))
     actionReader.blockchain = blockchain

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -48,21 +48,19 @@ export class BaseActionWatcher {
   protected async checkForBlocks(isReplay: boolean = false) {
     let headBlockNumber = 0
     while (!headBlockNumber || this.actionReader.currentBlockNumber < headBlockNumber) {
-      const [blockData, isRollback, isNewBlock] = await this.actionReader.nextBlock()
-      if (!isNewBlock) { break }
+      const [blockData, blockMeta] = await this.actionReader.nextBlock()
+      if (!blockMeta.isNewBlock) { break }
 
-      let needToSeek = false
-      let seekBlockNum = 0
+      let seekBlockNum = null
       if (blockData) {
-        [needToSeek, seekBlockNum] = await this.actionHandler.handleBlock(
+        seekBlockNum = await this.actionHandler.handleBlock(
           blockData,
-          isRollback,
-          this.actionReader.isFirstBlock,
+          blockMeta,
           isReplay,
         )
       }
 
-      if (needToSeek) {
+      if (seekBlockNum) {
         await this.actionReader.seekToBlock(seekBlockNum - 1)
       }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,33 @@
+export interface ActionReaderConfig {
+  /**
+   * For positive values, this sets the first block that this will start at. For negative
+   * values, this will start at (most recent block + startAtBlock), effectively tailing the
+   * chain. Be careful when using this feature, as this will make your starting block dynamic.
+   */
+  startAtBlock?: number
+  /**
+   * When false (default), `getHeadBlockNumber` will load the most recent block number. When
+   * true, `getHeadBlockNumber` will return the block number of the most recent irreversible
+   * block. Keep in mind that `getHeadBlockNumber` is an abstract method and this functionality
+   * is the responsibility of the implementing class.
+   */
+  onlyIrreversible?: boolean
+  /**
+   * This determines how many blocks in the past are cached. This is used for determining
+   * block validity during both normal operation and when rolling back.
+   */
+  maxHistoryLength?: number
+}
+
 export interface Block {
   actions: Action[]
   blockInfo: BlockInfo
+}
+
+export interface BlockMeta {
+  isRollback: boolean
+  isFirstBlock: boolean
+  isNewBlock: boolean
 }
 
 export interface IndexState {
@@ -53,4 +80,9 @@ export interface HandlerVersion {
   versionName: string
   updaters: Updater[]
   effects: Effect[]
+}
+
+export interface VersionedAction {
+  action: Action
+  handlerVersionName: string
 }

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -1,5 +1,5 @@
 import { AbstractActionHandler } from "../AbstractActionHandler"
-import { Action, Block, IndexState } from "../interfaces"
+import { Block, IndexState, VersionedAction } from "../interfaces"
 
 export class TestActionHandler extends AbstractActionHandler {
   public state: any = {
@@ -31,12 +31,12 @@ export class TestActionHandler extends AbstractActionHandler {
     block: Block,
     isReplay: boolean,
     context: any,
-  ): Promise<Array<[Action, string]>> {
+  ): Promise<VersionedAction[]> {
     return this.applyUpdaters(state, block, isReplay, context)
   }
 
   public _runEffects(
-    versionedActions: Array<[Action, string]>,
+    versionedActions: VersionedAction[],
     block: Block,
     context: any,
   ) {


### PR DESCRIPTION
- Put arguments to Action Reader's constructor into a config object
- Create BlockMeta interface to group flags sent from the Action Reader to the Action Handler
- Return value of handleBlock now returns just a number or null
- Refactor inline types to VersionedAction interface