### PR TITLE
Irreversible block number as maxHistory

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -109,7 +109,7 @@ describe("Action Handler", () => {
     const versionedActions = await actionHandler._applyUpdaters({}, blockchain[1], {},  false)
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: true,
+      isEarliestBlock: true,
       isNewBlock: true,
     }
     const nextBlock = {
@@ -129,7 +129,7 @@ describe("Action Handler", () => {
     }
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: true,
+      isEarliestBlock: true,
       isNewBlock: true,
     }
     const nextBlock = {
@@ -145,7 +145,7 @@ describe("Action Handler", () => {
     actionHandler.setLastProcessedBlockNumber(2)
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: false,
+      isEarliestBlock: false,
       isNewBlock: true,
     }
     const nextBlock = {
@@ -162,7 +162,7 @@ describe("Action Handler", () => {
     actionHandler.setLastProcessedBlockHash("asdfasdfasdf")
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: false,
+      isEarliestBlock: false,
       isNewBlock: true,
     }
     const expectedError = new Error("Block hashes do not match; block not part of current chain.")
@@ -177,7 +177,7 @@ describe("Action Handler", () => {
   it("upgrades the action handler correctly", async () => {
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: true,
+      isEarliestBlock: true,
       isNewBlock: true,
     }
     const nextBlock = {
@@ -202,7 +202,7 @@ describe("Action Handler", () => {
   it("defers the effects until the block is irreversible", async () => {
     const blockMeta = {
       isRollback: false,
-      isFirstBlock: true,
+      isEarliestBlock: true,
       isNewBlock: true,
     }
     const nextBlock = {
@@ -218,7 +218,7 @@ describe("Action Handler", () => {
 
     const blockMeta2 = {
       isRollback: false,
-      isFirstBlock: false,
+      isEarliestBlock: false,
       isNewBlock: true,
     }
     const nextBlock2 = {

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -44,9 +44,9 @@ export abstract class AbstractActionHandler {
   ): Promise<number | null> {
     const { block, blockMeta } = nextBlock
     const { blockInfo } = block
-    const { isRollback, isFirstBlock } = blockMeta
+    const { isRollback, isEarliestBlock } = blockMeta
 
-    if (isRollback || (isReplay && isFirstBlock)) {
+    if (isRollback || (isReplay && isEarliestBlock)) {
       const rollbackBlockNumber = blockInfo.blockNumber - 1
       const rollbackCount = this.lastProcessedBlockNumber - rollbackBlockNumber
       this.log.info(`Rolling back ${rollbackCount} blocks to block ${rollbackBlockNumber}...`)
@@ -65,11 +65,11 @@ export abstract class AbstractActionHandler {
     }
 
     // If it's the first block but we've already processed blocks, seek to next block
-    if (isFirstBlock && this.lastProcessedBlockHash) {
+    if (isEarliestBlock && this.lastProcessedBlockHash) {
       return nextBlockNeeded
     }
     // Only check if this is the block we need if it's not the first block
-    if (!isFirstBlock) {
+    if (!isEarliestBlock) {
       if (blockInfo.blockNumber !== nextBlockNeeded) {
         return nextBlockNeeded
       }

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -83,7 +83,6 @@ export abstract class AbstractActionReader {
     if (this.currentBlockNumber < this.headBlockNumber) {
       const unvalidatedBlockData = await this.getBlock(this.currentBlockNumber + 1)
 
-
       const expectedHash = this.currentBlockData.blockInfo.blockHash
       const actualHash = this.currentBlockNumber ?
         unvalidatedBlockData.blockInfo.previousBlockHash :
@@ -156,10 +155,8 @@ export abstract class AbstractActionReader {
       }
       this.logForkMismatch(currentBlockInfo, previousBlockInfo)
 
-      console.log(previousBlockData)
       this.currentBlockData = previousBlockData
       this.blockHistory.pop()
-      console.log(this.blockHistory)
     }
 
     if (this.blockHistory.length === 0) {
@@ -259,8 +256,6 @@ export abstract class AbstractActionReader {
   }
 
   private async addPreviousBlockToHistory(checkIrreversiblility: boolean = true) {
-    console.log(this.currentBlockData.blockInfo.blockNumber)
-    console.log(this.lastIrreversibleBlockNumber)
     if (this.currentBlockData.blockInfo.blockNumber < this.lastIrreversibleBlockNumber && checkIrreversiblility) {
       throw new Error("Last irreversible block has been passed without resolving fork")
     }

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -1,5 +1,6 @@
 import * as Logger from "bunyan"
 import { ActionReaderConfig, Block, BlockInfo, BlockMeta, NextBlock } from "./interfaces"
+import { ActionReaderOptions, Block, BlockInfo, BlockMeta, NextBlock } from "./interfaces"
 
 /**
  * Reads blocks from a blockchain, outputting normalized `Block` objects.

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -1,7 +1,7 @@
 import * as Logger from "bunyan"
 import { ActionReaderOptions, Block, BlockInfo, BlockMeta, NextBlock } from "./interfaces"
 
-const defaultBlock = {
+const defaultBlock: Block = {
   blockInfo: {
     blockNumber: 0,
     blockHash: "",
@@ -9,7 +9,7 @@ const defaultBlock = {
     timestamp: new Date(0),
   },
   actions: [],
-} as Block
+}
 
 /**
  * Reads blocks from a blockchain, outputting normalized `Block` objects.
@@ -63,11 +63,11 @@ export abstract class AbstractActionReader {
    * `nextBlock`.
    */
   public async getNextBlock(): Promise<NextBlock> {
-    const blockMeta = {
+    const blockMeta: BlockMeta = {
       isRollback: false,
       isNewBlock: false,
       isEarliestBlock: false,
-    } as BlockMeta
+    }
 
     // TODO: Should this only be called when updating headBlockNumber?
     this.lastIrreversibleBlockNumber = await this.getLastIrreversibleBlockNumber()

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -51,16 +51,13 @@ export class BaseActionWatcher {
       const nextBlock = await this.actionReader.getNextBlock()
       if (!nextBlock.blockMeta.isNewBlock) { break }
 
-      let seekBlockNum = null
-      if (nextBlock.block) {
-        seekBlockNum = await this.actionHandler.handleBlock(
-          nextBlock,
-          isReplay,
-        )
-      }
+      const nextBlockNumberNeeded = await this.actionHandler.handleBlock(
+        nextBlock,
+        isReplay,
+      )
 
-      if (seekBlockNum) {
-        await this.actionReader.seekToBlock(seekBlockNum - 1)
+      if (nextBlockNumberNeeded) {
+        await this.actionReader.seekToBlock(nextBlockNumberNeeded - 1)
       }
 
       headBlockNumber = this.actionReader.headBlockNumber

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,4 +1,4 @@
-export interface ActionReaderConfig {
+export interface ActionReaderOptions {
   /**
    * For positive values, this sets the first block that this will start at. For negative
    * values, this will start at (most recent block + startAtBlock), effectively tailing the

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,7 +26,7 @@ export interface Block {
 
 export interface BlockMeta {
   isRollback: boolean
-  isFirstBlock: boolean
+  isEarliestBlock: boolean
   isNewBlock: boolean
 }
 

--- a/src/testHelpers/TestActionReader.ts
+++ b/src/testHelpers/TestActionReader.ts
@@ -3,12 +3,24 @@ import { Block } from "../interfaces"
 
 export class TestActionReader extends AbstractActionReader {
   public blockchain: Block[] = []
+  public _testLastIrreversible: number = 0
+
+  public get _blockHistory() {
+    return this.blockHistory
+  }
+
+  public get _lastIrreversibleBlockNumber() {
+    return this.lastIrreversibleBlockNumber
+  }
 
   public async getHeadBlockNumber(): Promise<number> {
     return this.blockchain[this.blockchain.length - 1].blockInfo.blockNumber
   }
 
   public async getLastIrreversibleBlockNumber(): Promise<number> {
+    if (this._testLastIrreversible) {
+      return this._testLastIrreversible
+    }
     return this.getHeadBlockNumber()
   }
 


### PR DESCRIPTION
This PR removes maxHistory as an option for the `AbstractActionReader` and instead stores the minimum amount of needed history as defined by the `lastIrreversibleBlockNumber`.

In the process of implementing using `lastIrreversibleBlockNumber` instead of the `maxHistory` and extracting all the dependencies around `maxHistory`, there was quite a bit of refactoring needed, and more complementary refactoring has been included in this PR as well. This includes:

- No more nullable `currentBlockData`
- Method to reload block history from the chain, greatly reducing the complexity of `seekToBlock`
- Breaking out various parts of `getNextBlock` into private functions