### PR TITLE
Rollback fix

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -145,7 +145,13 @@ describe('Action Handler', () => {
   })
 
   it('seeks to the next block needed when block number doesn\'t match last processed block', async () => {
-    actionHandler.setLastProcessedBlockNumber(2)
+    actionHandler.setLastProcessedBlockNumber(blockchain[1].blockInfo.blockNumber)
+    actionHandler.setLastProcessedBlockHash(blockchain[1].blockInfo.blockHash)
+    actionHandler.state.indexState = {
+      ...actionHandler.state.indexState,
+      blockNumber: blockchain[1].blockInfo.blockNumber,
+      blockHash: blockchain[1].blockInfo.blockHash,
+    }
     const blockMeta = {
       isRollback: false,
       isEarliestBlock: false,

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -107,6 +107,7 @@ export abstract class AbstractActionHandler {
    */
   public async initialize(): Promise<void> {
     await this.setup()
+    await this.refreshIndexState()
   }
 
   /**

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -147,4 +147,27 @@ describe('BaseActionWatcher', () => {
       totalTransferred: 189,
     })
   })
+
+  it('continues indexing where action handler left off', async () => {
+    actionHandler.state.indexState = {
+      blockNumber: blockchain[2].blockInfo.blockNumber,
+      blockHash: blockchain[2].blockInfo.blockHash,
+      handlerVersionName: 'v1',
+    }
+    await actionWatcher._checkForBlocks()
+    expect(actionHandler.state.indexState.blockNumber).toEqual(4)
+    expect(actionReader.currentBlockNumber).toBe(4)
+    expect(actionReader.headBlockNumber).toBe(4)
+  })
+
+  it('resolves fork', async () => {
+    actionReader._testLastIrreversible = 1
+    actionReader.blockchain = blockchain.slice(0, 4)
+    await actionWatcher._checkForBlocks()
+    actionReader.blockchain = blockchains.forked
+    await actionWatcher._checkForBlocks()
+    expect(actionHandler.state.indexState.blockNumber).toEqual(5)
+    expect(actionReader.currentBlockNumber).toBe(5)
+    expect(actionReader.headBlockNumber).toBe(5)
+  })
 })

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -136,7 +136,7 @@ export class BaseActionWatcher {
       )
 
       if (nextBlockNumberNeeded) {
-        await this.actionReader.seekToBlock(nextBlockNumberNeeded - 1)
+        await this.actionReader.seekToBlock(nextBlockNumberNeeded)
       }
 
       headBlockNumber = this.actionReader.headBlockNumber

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -20,12 +20,12 @@ export class TestActionHandler extends AbstractActionHandler {
 
   public async rollbackTo(blockNumber: number) {
     this.setLastProcessedBlockNumber(blockNumber)
+    this.setLastProcessedBlockHash(this.hashHistory[blockNumber])
     this.state.indexState = {
       ...this.state.indexState,
       blockNumber,
       blockHash: this.hashHistory[blockNumber],
     }
-    this.setLastProcessedBlockHash(this.hashHistory[blockNumber])
   }
 
   public setLastProcessedBlockHash(hash: string) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "outDir": "dist",
+    "sourceMap": true,
 
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Resolves #119, with caveats.

There was an off-by-one error in the action watcher, leading the reader to seek to the wrong block, and have the whole thing fall into an infinite loop. This was hidden by the fact that the initial run of the Handler was not loading index state, so some of the tests that should have failed were not.

Digging into this revealed a more fundamental problem- rollbacks can only be initiated when the action reader sees them happening, with its occurrence stored in `AbstractActionReader#blockHistory`. If the indexState is on a forked block at startup, then the action reader will not have any way to know of this and send a block whose blockHash does not match.

I'll open another issue to continue the conversation about potential solutions.