### PR TITLE
Revert "add wildcard option to match action and or contract type"

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -125,34 +125,6 @@ describe('Action Handler', () => {
     expect(notRunEffect).not.toHaveBeenCalled()
   })
 
-  describe('matchActionType method', () => {
-    it('matches on exact matches', () => {
-      const match = actionHandler._matchActionType('eosio.token::issue', 'eosio.token::issue')
-      const dontMatch = actionHandler._matchActionType('eosio::issue', 'eosio.token::issue')
-      expect(match).toEqual(true)
-      expect(dontMatch).toEqual(false)
-    })
-
-    it('matches on wildcarded contract', () => {
-      const match = actionHandler._matchActionType('eosio.token::issue', '*::issue')
-      const dontMatch = actionHandler._matchActionType('eosio::issue', '*::bid')
-      expect(match).toEqual(true)
-      expect(dontMatch).toEqual(false)
-    })
-
-    it('matches on wildcarded action', () => {
-      const match = actionHandler._matchActionType('eosio.token::issue', 'eosio.token::*')
-      const dontMatch = actionHandler._matchActionType('eosio::issue', 'eosio.token::*')
-      expect(match).toEqual(true)
-      expect(dontMatch).toEqual(false)
-    })
-
-    it('matches on wildcarded contracts and actions', () => {
-      const match = actionHandler._matchActionType('eosio.token::issue', '*::*')
-      expect(match).toEqual(true)
-    })
-  })
-
   it('retrieves indexState when processing first block', async () => {
     actionHandler.state.indexState = {
       blockNumber: 3,

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -153,11 +153,7 @@ export abstract class AbstractActionHandler {
    * @param subscribedType  The type the Updater of Effect is subscribed to
    */
   protected matchActionType(candidateType: string, subscribedType: string): boolean {
-    const [ candidateContract, candidateAction ] = candidateType.split('::')
-    const [ subscribedContract, subscribedAction ] = subscribedType.split('::')
-    const contractsMatch = candidateContract === subscribedContract || subscribedContract === '*'
-    const actionsMatch = candidateAction === subscribedAction || subscribedAction === '*'
-    return contractsMatch && actionsMatch
+    return candidateType === subscribedType
   }
 
   /**

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -53,10 +53,6 @@ export class TestActionHandler extends AbstractActionHandler {
     this.runEffects(versionedActions, context, nextBlock)
   }
 
-  public _matchActionType(candidateType: string, subscribedType: string): boolean {
-    return this.matchActionType(candidateType, subscribedType)
-  }
-
   protected async loadIndexState(): Promise<IndexState> {
     return this.state.indexState
   }


### PR DESCRIPTION
Reverts EOSIO/demux-js#131

Should be in EOSIO/demux-js-postgres