### PR TITLE
Implement Effect Run Modes

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -113,6 +113,13 @@ export interface ReaderInfo {
   lastIrreversibleBlockNumber: number
 }
 
+export enum EffectRunMode {
+  All = 'all',
+  OnlyImmediate = 'onlyImmediate',
+  OnlyDeferred = 'onlyDeferred',
+  None = 'none',
+}
+
 export enum IndexingStatus {
   Initial = 'initial',
   Indexing = 'indexing',


### PR DESCRIPTION
Allows you do configure your Action Handler with the following Effect Run Modes:

- `all`: Processes all effects *(default)*
- `onlyDeferred`: Only processes effects that have `deferUntilIrreversible` set to `true`
- `onlyImmediate`: Only processes effects that have `deferUntilIrreversible` set to `false`
- `none`: Do not process any effects

These values are available as a new enum type `EffectRunMode`.