### PR TITLE
Move updating initialized state to inside initialize()

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -203,8 +203,7 @@ describe('Action Handler', () => {
     }
 
     const result = actionHandler.handleBlock(nextBlock, false)
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).rejects.toThrow(MismatchedBlockHashError)
+    await expect(result).rejects.toThrow(MismatchedBlockHashError)
   })
 
   it('upgrades the action handler correctly', async () => {
@@ -416,8 +415,7 @@ describe('Action Handler', () => {
     }
     actionHandler.isInitialized = false
     const result = actionHandler.handleBlock(nextBlock, false)
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).rejects.toThrow(NotInitializedError)
+    await expect(result).rejects.toThrow(NotInitializedError)
   })
 
   it(`doesn't run effect when effect mode is none`, async () => {

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -59,7 +59,6 @@ export abstract class AbstractActionHandler {
 
     if (!this.initialized) {
       await this.initialize()
-      this.initialized = true
     }
 
     await this.handleRollback(isRollback, blockInfo.blockNumber, isReplay, isEarliestBlock)
@@ -112,6 +111,7 @@ export abstract class AbstractActionHandler {
   public async initialize(): Promise<void> {
     await this.setup()
     await this.refreshIndexState()
+    this.initialized = true
   }
 
   /**

--- a/src/AbstractActionReader.test.ts
+++ b/src/AbstractActionReader.test.ts
@@ -72,8 +72,7 @@ describe('Action Reader', () => {
   it('does not seek to block earlier than startAtBlock', async () => {
     await actionReaderStartAt3.getNextBlock()
     const result = actionReaderStartAt3.seekToBlock(2)
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).rejects.toThrow(ImproperStartAtBlockError)
+    await expect(result).rejects.toThrow(ImproperStartAtBlockError)
   })
 
   it('handles rollback correctly', async () => {
@@ -129,7 +128,6 @@ describe('Action Reader', () => {
   it('continues ifSetup true', async () => {
     actionReader.isInitialized = false
     const result = actionReader.getNextBlock()
-    // tslint:disable-next-line:no-floating-promises
-    expect(result).rejects.toThrow(NotInitializedError)
+    await expect(result).rejects.toThrow(NotInitializedError)
   })
 })


### PR DESCRIPTION
Even when calling `initialize` before processing the first block, the `initialized` property would not update. This property now updates when `initialize()` is called directly.

This was discovered when awaiting `toThrow` calls in tests, which were being swallowed before. These tests are also fixed and now function properly.