### PR TITLE
`StatelessActionCallback`: `Block` -> `BlockInfo`

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -271,17 +271,17 @@ export abstract class AbstractActionHandler {
     context: any,
   ) {
     const { block, lastIrreversibleBlockNumber } = nextBlock
-    const { blockNumber } = block.blockInfo
+    const { blockInfo } = block
     const shouldRunImmediately = (
-      !effect.deferUntilIrreversible || block.blockInfo.blockNumber <= lastIrreversibleBlockNumber
+      !effect.deferUntilIrreversible || blockInfo.blockNumber <= lastIrreversibleBlockNumber
     )
     if (shouldRunImmediately) {
-      effect.run(payload, block, context)
+      effect.run(payload, blockInfo, context)
     } else {
-      if (!this.deferredEffects[blockNumber]) {
-        this.deferredEffects[blockNumber] = []
+      if (!this.deferredEffects[blockInfo.blockNumber]) {
+        this.deferredEffects[blockInfo.blockNumber] = []
       }
-      this.deferredEffects[blockNumber].push(() => effect.run(payload, block, context))
+      this.deferredEffects[blockInfo.blockNumber].push(() => effect.run(payload, blockInfo, context))
     }
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -64,7 +64,7 @@ export type ActionCallback = (
 
 export type StatelessActionCallback = (
   payload: any,
-  block: Block,
+  blockInfo: BlockInfo,
   context: any,
 ) => void | Promise<void>
 


### PR DESCRIPTION
The `StatelessActionCallback` type signature included `block: Block`, which is different than the `ActionCallback` apparently by mistake. Both `StatelessActionCallback` and `ActionCallback` now have `block: Block`, as there seems to be no reason for every effect run function to have access to the whole block it came from. (The mutable `context` object can be used to accumulate any needed data from within Updaters.)