### PR TITLE
Able to attempt to seek to head block + 1

### DIFF
--- a/src/AbstractActionReader.test.ts
+++ b/src/AbstractActionReader.test.ts
@@ -69,6 +69,13 @@ describe('Action Reader', () => {
     expect(block.blockInfo.blockNumber).toBe(2)
   })
 
+  it('seeks to head block + 1', async () => {
+    await actionReader.getNextBlock()
+    await actionReader.seekToBlock(5)
+    const { block } = await actionReader.getNextBlock()
+    expect(block.blockInfo.blockNumber).toBe(4)
+  })
+
   it('does not seek to block earlier than startAtBlock', async () => {
     await actionReaderStartAt3.getNextBlock()
     const result = actionReaderStartAt3.seekToBlock(2)

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -143,7 +143,7 @@ export abstract class AbstractActionReader {
     if (blockNumber < this.startAtBlock) {
       throw new ImproperStartAtBlockError()
     }
-    if (blockNumber > this.headBlockNumber) {
+    if (blockNumber > this.headBlockNumber + 1) {
       throw new ImproperSeekToBlockError(blockNumber)
     }
     this.currentBlockNumber = blockNumber - 1


### PR DESCRIPTION
If Demux is paused + resumed and no blocks were created in the interim, the Action Handler will send a signal to the Action Reader to seek to its next needed block, which may be ahead of the head block by at most 1. This PR allows for attempting to seek by 1 ahead of head block, which ultimately leads to just seeking to the head block. Since this block is the last processed block by the Action Handler, the Action Handler will simply ignore it until the reader gives it the next block (which was originally requested).