### PR TITLE
Fix failed to instantiate ActionHandler

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -144,7 +144,7 @@ export abstract class AbstractActionHandler {
   /**
    * Idempotently performs any required setup.
    */
-  protected abstract async setup(): Promise<void>
+  protected async setup(): Promise<void> {}
 
   /**
    * This method is used when matching the types of incoming actions against the types the `Updater`s and `Effect`s are


### PR DESCRIPTION
```
{
   "name":"demux",
   "hostname":"_",
   "pid":_,
   "level":50,
   "err":{
      "message":"this.setup is not a function",
      "name":"TypeError",
      "stack":"TypeError: this.setup is not a function
    at ObjectActionHandler.<anonymous> (/home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:98:24)
    at Generator.next (<anonymous>)
    at /home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:3:12)
    at ObjectActionHandler.initialize (/home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:97:16)
    at ObjectActionHandler.<anonymous> (/home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:51:28)
    at Generator.next (<anonymous>)
    at /home/_/eos-transfers/node_modules/demux/dist/AbstractActionHandler.js:7:71
    at new Promise (<anonymous>)"
   },
   "msg":"this.setup is not a function",
   "time":"2019-04-12T18:42:38.528Z",
   "v":0
}
```

``` typescript
protected abstract async setup(): Promise<void> {}
```

AbstractActionHandler.setup() is an abstract method, so its function definition is not generated by build. It causes an error when instantiating concrete ActionHandler in javascript. By dropping abstract modifier, AbstractActionHandler will have empty `setup()` method, so it can be instantiated.