### PR TITLE
Expose payload to `matchActionType`

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -6,7 +6,6 @@ import {
 } from './errors'
 import {
   Action,
-  BlockInfo,
   DeferredEffects,
   Effect,
   EffectRunMode,

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -6,6 +6,7 @@ import {
 } from './errors'
 import {
   Action,
+  BlockInfo,
   DeferredEffects,
   Effect,
   EffectRunMode,
@@ -155,8 +156,9 @@ export abstract class AbstractActionHandler {
    *
    * @param candidateType   The incoming action's type
    * @param subscribedType  The type the Updater of Effect is subscribed to
+   * @param _payload        The payload of the incoming action.
    */
-  protected matchActionType(candidateType: string, subscribedType: string): boolean {
+  protected matchActionType(candidateType: string, subscribedType: string, _payload: any): boolean { // tslint:disable-line
     return candidateType === subscribedType
   }
 
@@ -178,7 +180,7 @@ export abstract class AbstractActionHandler {
       let updaterIndex = -1
       for (const updater of this.handlerVersionMap[this.handlerVersionName].updaters) {
         updaterIndex += 1
-        if (this.matchActionType(action.type, updater.actionType)) {
+        if (this.matchActionType(action.type, updater.actionType, action.payload)) {
           const { payload } = action
           const newVersion = await updater.apply(state, payload, blockInfo, context)
           if (newVersion && !this.handlerVersionMap.hasOwnProperty(newVersion)) {
@@ -286,7 +288,7 @@ export abstract class AbstractActionHandler {
   }
 
   protected shouldRunOrDeferEffect(effect: Effect, action: Action) {
-    if (!this.matchActionType(action.type, effect.actionType)) {
+    if (!this.matchActionType(action.type, effect.actionType, action.payload)) {
       return false
     } else if (this.effectRunMode === EffectRunMode.None) {
       return false


### PR DESCRIPTION
This change exposes the action's payload to `AbstractActionHandler#matchActionType` so overriding methods may utilize it when determining if an action should be processed or not.