### PR TITLE
Handler debug logs + Deferred Effects Refactor

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -40,10 +40,11 @@ export abstract class AbstractActionHandler {
    *                         version name is `"v1"`.
    *
    * @param effectRunMode    An EffectRunMode that describes what effects should be run.
+   * @param options
    */
   constructor(
     handlerVersions: HandlerVersion[],
-    options: ActionReaderOptions,
+    options?: ActionReaderOptions,
   ) {
     const optionsWithDefaults = {
       effectRunMode: EffectRunMode.All,

--- a/src/ExpressActionWatcher.test.ts
+++ b/src/ExpressActionWatcher.test.ts
@@ -60,6 +60,9 @@ describe('ExpressActionWatcher', () => {
         lastProcessedBlockHash: '',
         lastProcessedBlockNumber: 0,
         handlerVersionName: 'v1',
+        effectRunMode: 'all',
+        effectErrors: [],
+        numberOfRunningEffects: 0,
       },
       reader: {
         currentBlockNumber: 0,
@@ -91,6 +94,9 @@ describe('ExpressActionWatcher', () => {
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
       handlerVersionName: 'v1',
+      effectRunMode: 'all',
+      effectErrors: [],
+      numberOfRunningEffects: 0,
     })
     expect(status.reader).toEqual({
       currentBlockNumber: 4,
@@ -117,6 +123,9 @@ describe('ExpressActionWatcher', () => {
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
       handlerVersionName: 'v1',
+      effectRunMode: 'all',
+      effectErrors: [],
+      numberOfRunningEffects: 0,
     })
     expect(status1.reader).toEqual({
       currentBlockNumber: 4,
@@ -133,6 +142,9 @@ describe('ExpressActionWatcher', () => {
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
       handlerVersionName: 'v1',
+      effectRunMode: 'all',
+      effectErrors: [],
+      numberOfRunningEffects: 0,
     })
     expect(status2.reader).toEqual({
       currentBlockNumber: 4,

--- a/src/ExpressActionWatcher.ts
+++ b/src/ExpressActionWatcher.ts
@@ -22,7 +22,7 @@ export class ExpressActionWatcher extends BaseActionWatcher {
   ) {
     super(actionReader, actionHandler, options)
 
-    this.port = options.port
+    this.port = options.port || 56544
 
     this.express.get('/info', (_, res: express.Response) => {
       res.json(this.info)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -33,6 +33,7 @@ export interface JsonActionReaderOptions extends ActionReaderOptions {
 
 export interface ActionReaderOptions {
   effectRunMode?: EffectRunMode
+  maxEffectErrors?: number
   logLevel?: LogLevel
 }
 
@@ -113,17 +114,25 @@ export interface VersionedAction {
 }
 
 export type CurriedEffectRun = (
-  () => void | Promise<void>
+  (currentBlockNumber: number, immediate?: boolean) => Promise<void>
 )
 
 export interface DeferredEffects {
   [blockNumber: number]: CurriedEffectRun[]
 }
 
+export interface EffectsInfo {
+  numberOfRunningEffects: number
+  effectErrors: string[]
+}
+
 export interface HandlerInfo {
   lastProcessedBlockNumber: number
   lastProcessedBlockHash: string
   handlerVersionName: string
+  effectRunMode: EffectRunMode
+  numberOfRunningEffects: number
+  effectErrors: string[]
 }
 
 export interface ReaderInfo {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,7 +24,7 @@ export interface ActionWatcherOptions {
 }
 
 export interface ExpressActionWatcherOptions extends ActionWatcherOptions {
-  port: number
+  port?: number
 }
 
 export interface JsonActionReaderOptions extends ActionReaderOptions {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,11 @@ export interface JsonActionReaderOptions extends ActionReaderOptions {
   blockchain: Block[]
 }
 
+export interface ActionReaderOptions {
+  effectRunMode?: EffectRunMode
+  logLevel?: LogLevel
+}
+
 export interface Block {
   actions: Action[]
   blockInfo: BlockInfo

--- a/src/makeQueryablePromise.ts
+++ b/src/makeQueryablePromise.ts
@@ -1,0 +1,39 @@
+export interface QueryablePromise<T> extends Promise<T> {
+  isFulfilled(): boolean
+  isPending(): boolean
+  isRejected(): boolean
+  value(): any
+  error(): Error | null
+}
+
+export const makeQuerablePromise = <T>(promise: Promise<T>, throwOnError: boolean = true): QueryablePromise<T> => {
+  let isPending = true
+  let isRejected = false
+  let isFulfilled = false
+  let value: any = null
+  let error: Error | null = null
+
+  const result = promise.then(
+    (fulfilledValue: any) => {
+      isFulfilled = true
+      isPending = false
+      value = fulfilledValue
+      return fulfilledValue
+    },
+    (err: Error) => {
+      isRejected = true
+      isPending = false
+      error = err
+      if (throwOnError) {
+        throw err
+      }
+    }
+  ) as QueryablePromise<T>
+
+  result.isFulfilled = () => isFulfilled
+  result.isPending = () => isPending
+  result.isRejected = () => isRejected
+  result.value = () => value
+  result.error = () => error
+  return result
+}

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -45,12 +45,12 @@ export class TestActionHandler extends AbstractActionHandler {
     return this.applyUpdaters(state, nextBlock, context, isReplay)
   }
 
-  public _runEffects(
+  public async _runEffects(
     versionedActions: VersionedAction[],
     context: any,
     nextBlock: NextBlock,
   ) {
-    this.runEffects(versionedActions, context, nextBlock)
+    await this.runEffects(versionedActions, context, nextBlock)
   }
 
   protected async loadIndexState(): Promise<IndexState> {

--- a/src/testHelpers/wait.ts
+++ b/src/testHelpers/wait.ts
@@ -1,0 +1,12 @@
+export const wait = (ms: number, mockCallback?: any): Promise<void> => {
+  if (mockCallback === undefined) {
+    mockCallback = () => (undefined)
+  }
+  return new Promise((resolve) => {
+    const callback = () => {
+      mockCallback()
+      resolve()
+    }
+    setTimeout(callback, ms)
+  })
+}


### PR DESCRIPTION
For the `AbstractActionHandler`:
- Created options object 
- Added logging
- In order to effectively add logging for Effects, we now handle effects and deferred effects in a more predictable / controlled way (a refactor this code was due for anyway)
- You can now check to see how many deferred Effects are currently running from `#info.numberOfRunningEffects`, (exposed via the `ExpressActionWatcher`)
- When Effects throw, their traceback is persisted and also accessible via `#info.effectErrors`. You can configure the maximum kept number errors via `options.maxEffectErrors`