### PR TITLE
Fix ActionHandlerOptions interface

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -6,12 +6,13 @@ import {
 } from './errors'
 import {
   Action,
-  ActionReaderOptions,
+  ActionHandlerOptions,
   BlockInfo,
   CurriedEffectRun,
   DeferredEffects,
   Effect,
-  EffectRunMode, EffectsInfo,
+  EffectRunMode,
+  EffectsInfo,
   HandlerInfo,
   HandlerVersion,
   IndexState,
@@ -49,7 +50,7 @@ export abstract class AbstractActionHandler {
    */
   constructor(
     handlerVersions: HandlerVersion[],
-    options?: ActionReaderOptions,
+    options?: ActionHandlerOptions,
   ) {
     const optionsWithDefaults = {
       effectRunMode: EffectRunMode.All,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,7 +31,7 @@ export interface JsonActionReaderOptions extends ActionReaderOptions {
   blockchain: Block[]
 }
 
-export interface ActionReaderOptions {
+export interface ActionHandlerOptions {
   effectRunMode?: EffectRunMode
   maxEffectErrors?: number
   logLevel?: LogLevel


### PR DESCRIPTION
Accidentally overloaded existing `ActionReaderOptions` interface, this correctly makes a distinct `ActionHandlerOptions` interface