### PR TITLE
Persist all IndexState values to AbstractActionHandler

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -34,6 +34,7 @@ export abstract class AbstractActionHandler {
   public lastProcessedBlockHash: string = ''
   public lastIrreversibleBlockNumber: number = 0
   public handlerVersionName: string = 'v1'
+  public isReplay: boolean = false
   protected log: Logger
   protected effectRunMode: EffectRunMode
   protected initialized: boolean = false
@@ -463,11 +464,12 @@ export abstract class AbstractActionHandler {
   private async refreshIndexState() {
     this.log.debug('Loading Index State...')
     const refreshStart = Date.now()
-    const { blockNumber, blockHash, handlerVersionName, lastIrreversibleBlockNumber } = await this.loadIndexState()
-    this.lastProcessedBlockNumber = blockNumber
-    this.lastProcessedBlockHash = blockHash
-    this.lastIrreversibleBlockNumber = lastIrreversibleBlockNumber
-    this.handlerVersionName = handlerVersionName
+    const indexState = await this.loadIndexState()
+    this.lastProcessedBlockNumber = indexState.blockNumber
+    this.lastProcessedBlockHash = indexState.blockHash
+    this.lastIrreversibleBlockNumber = indexState.lastIrreversibleBlockNumber
+    this.handlerVersionName = indexState.handlerVersionName
+    this.isReplay = indexState.isReplay
     const refreshTime = Date.now() - refreshStart
     this.log.debug(`Loaded Index State (${refreshTime}ms)`)
   }

--- a/src/testHelpers/TestActionHandler.ts
+++ b/src/testHelpers/TestActionHandler.ts
@@ -5,9 +5,15 @@ import { IndexState, NextBlock, VersionedAction } from '../interfaces'
 export class TestActionHandler extends AbstractActionHandler {
   public isInitialized: boolean = false
 
-  public state: any = {
-    indexState: { blockNumber: 0, blockHash: '', isReplay: false, handlerVersionName: 'v1' },
+  private indexState: IndexState = {
+    blockNumber: 0,
+    blockHash: '',
+    isReplay: false,
+    handlerVersionName: 'v1',
+    lastIrreversibleBlockNumber: 0
   }
+
+  public state: any = { indexState: this.indexState }
 
   private hashHistory: { [key: number]: string } = { 0: '' }
 
@@ -30,10 +36,12 @@ export class TestActionHandler extends AbstractActionHandler {
 
   public setLastProcessedBlockHash(hash: string) {
     this.lastProcessedBlockHash = hash
+    this.indexState.blockHash = hash
   }
 
   public setLastProcessedBlockNumber(num: number) {
     this.lastProcessedBlockNumber = num
+    this.indexState.blockNumber = num
   }
 
   public async _applyUpdaters(


### PR DESCRIPTION
- Adds `lastIrreversibleBlockNumber` and `isReplay` properties to `AbstractActionHandler`, which completes the cache of index state's values
- Always refreshes index state before applying updaters