### PR TITLE
Created an IActionReader Interface

### DIFF
--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -12,6 +12,7 @@ import {
   BlockMeta,
   NextBlock,
   ReaderInfo,
+  IActionReader
 } from './interfaces'
 
 const defaultBlock: Block = {
@@ -27,7 +28,7 @@ const defaultBlock: Block = {
 /**
  * Reads blocks from a blockchain, outputting normalized `Block` objects.
  */
-export abstract class AbstractActionReader {
+export abstract class AbstractActionReader implements IActionReader {
   public startAtBlock: number
   public headBlockNumber: number = 0
   public currentBlockNumber: number

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -12,7 +12,7 @@ import {
   BlockMeta,
   NextBlock,
   ReaderInfo,
-  IActionReader
+  IActionReader,
 } from './interfaces'
 
 const defaultBlock: Block = {

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -1,15 +1,14 @@
 import { AbstractActionHandler } from './AbstractActionHandler'
-import { AbstractActionReader } from './AbstractActionReader'
 import { BunyanProvider, Logger, LogLevel } from './BunyanProvider'
-import { ActionWatcherOptions, DemuxInfo, IndexingStatus, WatcherInfo } from './interfaces'
+import { ActionWatcherOptions, DemuxInfo, IndexingStatus, WatcherInfo, IActionReader } from './interfaces'
 
 /**
- * Coordinates implementations of `AbstractActionReader`s and `AbstractActionHandler`s in
+ * Coordinates implementations of `IActionReader`s and `AbstractActionHandler`s in
  * a polling loop.
  */
 export class BaseActionWatcher {
   /**
-   * @param actionReader    An instance of an implemented `AbstractActionReader`
+   * @param actionReader    An instance of an implemented `IActionReader`
    * @param actionHandler   An instance of an implemented `AbstractActionHandler`
    * @param options
    */
@@ -24,7 +23,7 @@ export class BaseActionWatcher {
   private clean: boolean = true
 
   constructor(
-    protected actionReader: AbstractActionReader,
+    protected actionReader: IActionReader,
     protected actionHandler: AbstractActionHandler,
     options: ActionWatcherOptions,
   ) {

--- a/src/ExpressActionWatcher.ts
+++ b/src/ExpressActionWatcher.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import * as http from 'http'
 import { AbstractActionHandler } from './AbstractActionHandler'
 import { BaseActionWatcher } from './BaseActionWatcher'
-import { ExpressActionWatcherOptions, IActionReader } from "./interfaces";
+import { ExpressActionWatcherOptions, IActionReader } from './interfaces';
 
 /**
  * Exposes the BaseActionWatcher's API methods through a simple REST interface using Express

--- a/src/ExpressActionWatcher.ts
+++ b/src/ExpressActionWatcher.ts
@@ -1,9 +1,8 @@
 import express from 'express'
 import * as http from 'http'
 import { AbstractActionHandler } from './AbstractActionHandler'
-import { AbstractActionReader } from './AbstractActionReader'
 import { BaseActionWatcher } from './BaseActionWatcher'
-import { ExpressActionWatcherOptions } from './interfaces'
+import { ExpressActionWatcherOptions, IActionReader } from "./interfaces";
 
 /**
  * Exposes the BaseActionWatcher's API methods through a simple REST interface using Express
@@ -16,7 +15,7 @@ export class ExpressActionWatcher extends BaseActionWatcher {
   protected port: number
   private server: http.Server | null = null
   constructor(
-    protected actionReader: AbstractActionReader,
+    protected actionReader: IActionReader,
     protected actionHandler: AbstractActionHandler,
     protected options: ExpressActionWatcherOptions,
   ) {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -175,15 +175,15 @@ export interface DemuxInfo {
 }
 
 export interface IActionReader {
-  startAtBlock: number;
-  headBlockNumber: number;
-  currentBlockNumber: number;
-  info: ReaderInfo;
+  startAtBlock: number
+  headBlockNumber: number
+  currentBlockNumber: number
+  info: ReaderInfo
 
-  getHeadBlockNumber(): Promise<number>;
-  getLastIrreversibleBlockNumber(): Promise<number>;
-  getBlock(blockNumber: number): Promise<Block>;
-  getNextBlock(): Promise<NextBlock>;
-  initialize(): Promise<void>;
-  seekToBlock(blockNumber: number): Promise<void>;
+  getHeadBlockNumber(): Promise<number>
+  getLastIrreversibleBlockNumber(): Promise<number>
+  getBlock(blockNumber: number): Promise<Block>
+  getNextBlock(): Promise<NextBlock>
+  initialize(): Promise<void>
+  seekToBlock(blockNumber: number): Promise<void>
 }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -173,3 +173,17 @@ export interface DemuxInfo {
   handler: HandlerInfo
   reader: ReaderInfo
 }
+
+export interface IActionReader {
+  startAtBlock: number;
+  headBlockNumber: number;
+  currentBlockNumber: number;
+  info: ReaderInfo;
+
+  getHeadBlockNumber(): Promise<number>;
+  getLastIrreversibleBlockNumber(): Promise<number>;
+  getBlock(blockNumber: number): Promise<Block>;
+  getNextBlock(): Promise<NextBlock>;
+  initialize(): Promise<void>;
+  seekToBlock(blockNumber: number): Promise<void>;
+}


### PR DESCRIPTION
Fixes #165.

The problem this aims to solve is that `AbstractActionReader` is not super flexible, since you are obligated to keep its private parts. It makes extending it quite tricky, if you don't need the private parts for your ActionReader to work.

To make it more flexible, an IActionReader interface was created, and that is now what other classes look require.