### PR TITLE
Refactor out public interfaces ActionReader and ActionWatcher

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -33,14 +33,14 @@ describe('Action Handler', () => {
 
   beforeEach(() => {
     runUpdater = jest.fn()
-    runEffect = jest.fn()
+    runEffect = jest.fn().mockResolvedValue(undefined)
 
     notRunUpdater = jest.fn()
-    notRunEffect = jest.fn()
+    notRunEffect = jest.fn().mockResolvedValue(undefined)
 
-    startSlowEffect = jest.fn()
+    startSlowEffect = jest.fn().mockResolvedValue(undefined)
     finishSlowEffect = jest.fn()
-    startThrownEffect = jest.fn()
+    startThrownEffect = jest.fn().mockResolvedValue(undefined)
 
     runUpgradeUpdater = jest.fn().mockReturnValue('v2')
 
@@ -86,15 +86,15 @@ describe('Action Handler', () => {
           {
             actionType: 'testing::action',
             run: async () => {
-              startSlowEffect()
+              await startSlowEffect()
               await wait(100, finishSlowEffect)
             },
             deferUntilIrreversible: false,
           },
           {
             actionType: 'eosio.system::regproducer',
-            run: () => {
-              startThrownEffect()
+            run: async () => {
+              await startThrownEffect()
               throw Error('Thrown effect')
             }
           }
@@ -352,7 +352,7 @@ describe('Action Handler', () => {
     }
     await actionHandler.handleBlock(rollback2, false)
 
-    expect(actionHandler.lastProcessedBlockNumber).toEqual(2)
+    expect(actionHandler.info.lastProcessedBlockNumber).toEqual(2)
   })
 
   it(`doesn't run effects from orphaned blocks`, async () => {
@@ -540,6 +540,6 @@ describe('Action Handler', () => {
     expect(startThrownEffect).toHaveBeenCalled()
     expect(actionHandler.info.numberOfRunningEffects).toEqual(0)
     expect(actionHandler.info.effectErrors).toHaveLength(1)
-    expect(actionHandler.info.effectErrors[0].startsWith('Error: Thrown effect')).toBeTruthy()
+    expect(actionHandler.info.effectErrors![0].startsWith('Error: Thrown effect')).toBeTruthy()
   })
 })

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -6,6 +6,7 @@ import {
 } from './errors'
 import {
   Action,
+  ActionHandler,
   ActionHandlerOptions,
   BlockInfo,
   CurriedEffectRun,
@@ -28,12 +29,12 @@ import { QueryablePromise, makeQuerablePromise } from './makeQueryablePromise'
  * `loadIndexState`. Implement `rollbackTo` to handle when a fork is encountered.
  *
  */
-export abstract class AbstractActionHandler {
-  public lastProcessedBlockNumber: number = 0
-  public lastProcessedBlockHash: string = ''
-  public lastIrreversibleBlockNumber: number = 0
-  public handlerVersionName: string = 'v1'
-  public isReplay: boolean = false
+export abstract class AbstractActionHandler implements ActionHandler {
+  protected lastProcessedBlockNumber: number = 0
+  protected lastProcessedBlockHash: string = ''
+  protected lastIrreversibleBlockNumber: number = 0
+  protected handlerVersionName: string = 'v1'
+  protected isReplay: boolean = false
   protected log: Logger
   protected effectRunMode: EffectRunMode
   protected initialized: boolean = false
@@ -130,7 +131,9 @@ export abstract class AbstractActionHandler {
     return {
       lastProcessedBlockNumber: this.lastProcessedBlockNumber,
       lastProcessedBlockHash: this.lastProcessedBlockHash,
+      lastIrreversibleBlockNumber: this.lastIrreversibleBlockNumber,
       handlerVersionName: this.handlerVersionName,
+      isReplay: this.isReplay,
       effectRunMode: this.effectRunMode,
       numberOfRunningEffects: effectInfo.numberOfRunningEffects,
       effectErrors: effectInfo.effectErrors,

--- a/src/AbstractActionReader.ts
+++ b/src/AbstractActionReader.ts
@@ -6,6 +6,7 @@ import {
   UnresolvedForkError,
 } from './errors'
 import {
+  ActionReader,
   ActionReaderOptions,
   Block,
   BlockInfo,
@@ -27,10 +28,10 @@ const defaultBlock: Block = {
 /**
  * Reads blocks from a blockchain, outputting normalized `Block` objects.
  */
-export abstract class AbstractActionReader {
-  public startAtBlock: number
-  public headBlockNumber: number = 0
-  public currentBlockNumber: number
+export abstract class AbstractActionReader implements ActionReader {
+  protected startAtBlock: number
+  protected headBlockNumber: number = 0
+  protected currentBlockNumber: number
   protected onlyIrreversible: boolean
   protected currentBlockData: Block = defaultBlock
   protected lastIrreversibleBlockNumber: number = 0
@@ -52,23 +53,6 @@ export abstract class AbstractActionReader {
 
     this.log = BunyanProvider.getLogger(optionsWithDefaults)
   }
-
-  /**
-   * Loads the number of the latest block.
-   */
-  public abstract async getHeadBlockNumber(): Promise<number>
-
-  /**
-   * Loads the number of the most recent irreversible block.
-   */
-  public abstract async getLastIrreversibleBlockNumber(): Promise<number>
-
-  /**
-   * Loads a block with the given block number, returning a promise for a `Block`.
-   *
-   * @param blockNumber  The number of the block to load
-   */
-  public abstract async getBlock(blockNumber: number): Promise<Block>
 
   /**
    * Loads, processes, and returns the next block, updating all relevant state. Return value at index 0 is the `Block`
@@ -187,6 +171,23 @@ export abstract class AbstractActionReader {
       lastIrreversibleBlockNumber: this.lastIrreversibleBlockNumber,
     }
   }
+
+  /**
+   * Loads the number of the latest block.
+   */
+  protected abstract async getHeadBlockNumber(): Promise<number>
+
+  /**
+   * Loads the number of the most recent irreversible block.
+   */
+  protected abstract async getLastIrreversibleBlockNumber(): Promise<number>
+
+  /**
+   * Loads a block with the given block number, returning a promise for a `Block`.
+   *
+   * @param blockNumber  The number of the block to load
+   */
+  protected abstract async getBlock(blockNumber: number): Promise<Block>
 
   /**
    * Idempotently performs any required setup.

--- a/src/BaseActionWatcher.test.ts
+++ b/src/BaseActionWatcher.test.ts
@@ -87,7 +87,7 @@ describe('BaseActionWatcher', () => {
       },
       totalTransferred: 66,
     })
-    expect(actionReader.currentBlockNumber).toBe(4)
+    expect(actionReader.info.currentBlockNumber).toBe(4)
   })
 
   it('processes blocks starting at block 3', async () => {
@@ -101,7 +101,7 @@ describe('BaseActionWatcher', () => {
       },
       totalTransferred: 24,
     })
-    expect(actionReaderStartAt3.currentBlockNumber).toBe(4)
+    expect(actionReaderStartAt3.info.currentBlockNumber).toBe(4)
   })
 
   it('processes blocks starting at block 3 (negative indexed)', async () => {
@@ -115,7 +115,7 @@ describe('BaseActionWatcher', () => {
       },
       totalTransferred: 24,
     })
-    expect(actionReaderNegative.currentBlockNumber).toBe(4)
+    expect(actionReaderNegative.info.currentBlockNumber).toBe(4)
   })
 
   it('processes blocks after seeing more blocks', async () => {
@@ -164,8 +164,8 @@ describe('BaseActionWatcher', () => {
     }
     await actionWatcher._checkForBlocks()
     expect(actionHandler.state.indexState.blockNumber).toEqual(4)
-    expect(actionReader.currentBlockNumber).toBe(4)
-    expect(actionReader.headBlockNumber).toBe(4)
+    expect(actionReader.info.currentBlockNumber).toBe(4)
+    expect(actionReader.info.headBlockNumber).toBe(4)
   })
 
   it('resolves fork', async () => {
@@ -175,8 +175,8 @@ describe('BaseActionWatcher', () => {
     actionReader.blockchain = blockchains.forked
     await actionWatcher._checkForBlocks()
     expect(actionHandler.state.indexState.blockNumber).toEqual(5)
-    expect(actionReader.currentBlockNumber).toBe(5)
-    expect(actionReader.headBlockNumber).toBe(5)
+    expect(actionReader.info.currentBlockNumber).toBe(5)
+    expect(actionReader.info.headBlockNumber).toBe(5)
   })
 
   it('gives the correct block velocity', () => {

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -2,13 +2,13 @@ import { BunyanProvider, Logger, LogLevel } from './BunyanProvider'
 import { ActionHandler, ActionReader, ActionWatcherOptions, DemuxInfo, IndexingStatus, WatcherInfo } from './interfaces'
 
 /**
- * Coordinates implementations of `AbstractActionReader`s and `AbstractActionHandler`s in
+ * Coordinates implementations of `ActionReader`s and `ActionHandler`s in
  * a polling loop.
  */
 export class BaseActionWatcher {
   /**
-   * @param actionReader    An instance of an implemented `AbstractActionReader`
-   * @param actionHandler   An instance of an implemented `AbstractActionHandler`
+   * @param actionReader    An instance of an implemented `ActionReader`
+   * @param actionHandler   An instance of an implemented `ActionHandler`
    * @param options
    */
 

--- a/src/BaseActionWatcher.ts
+++ b/src/BaseActionWatcher.ts
@@ -1,7 +1,5 @@
-import { AbstractActionHandler } from './AbstractActionHandler'
-import { AbstractActionReader } from './AbstractActionReader'
 import { BunyanProvider, Logger, LogLevel } from './BunyanProvider'
-import { ActionWatcherOptions, DemuxInfo, IndexingStatus, WatcherInfo } from './interfaces'
+import { ActionHandler, ActionReader, ActionWatcherOptions, DemuxInfo, IndexingStatus, WatcherInfo } from './interfaces'
 
 /**
  * Coordinates implementations of `AbstractActionReader`s and `AbstractActionHandler`s in
@@ -24,8 +22,8 @@ export class BaseActionWatcher {
   private clean: boolean = true
 
   constructor(
-    protected actionReader: AbstractActionReader,
-    protected actionHandler: AbstractActionHandler,
+    protected actionReader: ActionReader,
+    protected actionHandler: ActionHandler,
     options: ActionWatcherOptions,
   ) {
     const optionsWithDefaults = {
@@ -144,13 +142,13 @@ export class BaseActionWatcher {
    */
   protected async checkForBlocks(isReplay: boolean = false) {
     let headBlockNumber = 0
-    while (!headBlockNumber || this.actionReader.currentBlockNumber < headBlockNumber) {
+    while (!headBlockNumber || this.actionReader.info.currentBlockNumber < headBlockNumber) {
       if (this.shouldPause) {
         this.processIntervals = []
         return
       }
       const readStartTime = Date.now()
-      this.log.debug(`Processing block ${this.actionReader.currentBlockNumber + 1}...`)
+      this.log.debug(`Processing block ${this.actionReader.info.currentBlockNumber + 1}...`)
       const nextBlock = await this.actionReader.getNextBlock()
       const readDuration = Date.now() - readStartTime
       if (!nextBlock.blockMeta.isNewBlock) { break }
@@ -172,7 +170,7 @@ export class BaseActionWatcher {
         await this.actionReader.seekToBlock(nextBlockNumberNeeded)
       }
 
-      headBlockNumber = this.actionReader.headBlockNumber
+      headBlockNumber = this.actionReader.info.headBlockNumber
     }
   }
 

--- a/src/ExpressActionWatcher.test.ts
+++ b/src/ExpressActionWatcher.test.ts
@@ -59,6 +59,8 @@ describe('ExpressActionWatcher', () => {
       handler: {
         lastProcessedBlockHash: '',
         lastProcessedBlockNumber: 0,
+        isReplay: false,
+        lastIrreversibleBlockNumber: 0,
         handlerVersionName: 'v1',
         effectRunMode: 'all',
         effectErrors: [],
@@ -93,6 +95,7 @@ describe('ExpressActionWatcher', () => {
     expect(status.handler).toEqual({
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
+      isReplay: false,
       handlerVersionName: 'v1',
       effectRunMode: 'all',
       effectErrors: [],
@@ -122,6 +125,7 @@ describe('ExpressActionWatcher', () => {
     expect(status1.handler).toEqual({
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
+      isReplay: false,
       handlerVersionName: 'v1',
       effectRunMode: 'all',
       effectErrors: [],
@@ -141,6 +145,7 @@ describe('ExpressActionWatcher', () => {
     expect(status2.handler).toEqual({
       lastProcessedBlockHash: '0000000000000000000000000000000000000000000000000000000000000003',
       lastProcessedBlockNumber: 4,
+      isReplay: false,
       handlerVersionName: 'v1',
       effectRunMode: 'all',
       effectErrors: [],

--- a/src/ExpressActionWatcher.ts
+++ b/src/ExpressActionWatcher.ts
@@ -8,8 +8,11 @@ import { ActionHandler, ActionReader, ExpressActionWatcherOptions } from './inte
  */
 export class ExpressActionWatcher extends BaseActionWatcher {
   /**
-   * @param port  The port to use for the Express server
+   * @param actionReader    An instance of an implemented `ActionReader`
+   * @param actionHandler   An instance of an implemented `ActionHandler`
+   * @param options
    */
+
   public express: express.Express = express() // How expressive
   protected port: number
   private server: http.Server | null = null

--- a/src/ExpressActionWatcher.ts
+++ b/src/ExpressActionWatcher.ts
@@ -1,9 +1,7 @@
 import express from 'express'
 import * as http from 'http'
-import { AbstractActionHandler } from './AbstractActionHandler'
-import { AbstractActionReader } from './AbstractActionReader'
 import { BaseActionWatcher } from './BaseActionWatcher'
-import { ExpressActionWatcherOptions } from './interfaces'
+import { ActionHandler, ActionReader, ExpressActionWatcherOptions } from './interfaces'
 
 /**
  * Exposes the BaseActionWatcher's API methods through a simple REST interface using Express
@@ -16,8 +14,8 @@ export class ExpressActionWatcher extends BaseActionWatcher {
   protected port: number
   private server: http.Server | null = null
   constructor(
-    protected actionReader: AbstractActionReader,
-    protected actionHandler: AbstractActionHandler,
+    protected actionReader: ActionReader,
+    protected actionHandler: ActionHandler,
     protected options: ExpressActionWatcherOptions,
   ) {
     super(actionReader, actionHandler, options)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,5 +1,12 @@
 import { LogLevel } from './BunyanProvider'
 
+export interface ActionReader {
+  getNextBlock(): Promise<NextBlock>
+  initialize(): Promise<void>
+  seekToBlock(blockNumber: number): Promise<void>
+  readonly info: ReaderInfo
+}
+
 export interface LogOptions {
   logSource?: string
   logLevel?: LogLevel
@@ -32,6 +39,12 @@ export interface ExpressActionWatcherOptions extends ActionWatcherOptions {
 
 export interface JsonActionReaderOptions extends ActionReaderOptions {
   blockchain: Block[]
+}
+
+export interface ActionHandler {
+  handleBlock(nextBlock: NextBlock, isReplay: boolean): Promise<number | null>
+  initialize(): Promise<void>
+  readonly info: HandlerInfo
 }
 
 export interface ActionHandlerOptions extends LogOptions {
@@ -131,18 +144,20 @@ export interface EffectsInfo {
 export interface HandlerInfo {
   lastProcessedBlockNumber: number
   lastProcessedBlockHash: string
+  lastIrreversibleBlockNumber: number
   handlerVersionName: string
-  effectRunMode: EffectRunMode
-  numberOfRunningEffects: number
-  effectErrors: string[]
+  isReplay?: boolean
+  effectRunMode?: EffectRunMode
+  numberOfRunningEffects?: number
+  effectErrors?: string[]
 }
 
 export interface ReaderInfo {
   currentBlockNumber: number
   startAtBlock: number
   headBlockNumber: number
-  onlyIrreversible: boolean
-  lastIrreversibleBlockNumber: number
+  onlyIrreversible?: boolean
+  lastIrreversibleBlockNumber?: number
 }
 
 export enum EffectRunMode {


### PR DESCRIPTION
Closes #165, #168 

In an attempt to make the public interface as lean as possible, I went ahead and switched some public properties to protected. @olivierbeaulieu, let me know if this works for you!