### PR TITLE
Add option to turn off ActionHandler block hash consistency validation

### DIFF
--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -43,6 +43,7 @@ export abstract class AbstractActionHandler implements ActionHandler {
   private runningEffects: Array<QueryablePromise<void>> = []
   private effectErrors: string[] = []
   private maxEffectErrors: number
+  private validateBlockHashes: boolean
 
   /**
    * @param handlerVersions  An array of `HandlerVersion`s that are to be used when processing blocks. The default
@@ -59,12 +60,14 @@ export abstract class AbstractActionHandler implements ActionHandler {
       logSource: 'AbstractActionHandler',
       logLevel: 'info' as LogLevel,
       maxEffectErrors: 100,
+      validateBlockHashes: true,
       ...options,
     }
     this.initHandlerVersions(handlerVersions)
     this.effectRunMode = optionsWithDefaults.effectRunMode
     this.maxEffectErrors = optionsWithDefaults.maxEffectErrors
     this.log = BunyanProvider.getLogger(optionsWithDefaults)
+    this.validateBlockHashes = optionsWithDefaults.validateBlockHashes
   }
 
   /**
@@ -109,10 +112,12 @@ export abstract class AbstractActionHandler implements ActionHandler {
         return nextBlockNeeded
       }
       // Block sequence consistency should be handled by the ActionReader instance
-      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash) {
-        throw new MismatchedBlockHashError(blockInfo.blockNumber,
-                                           this.lastProcessedBlockHash,
-                                           blockInfo.previousBlockHash)
+      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash && this.validateBlockHashes) {
+        throw new MismatchedBlockHashError(
+          blockInfo.blockNumber,
+          this.lastProcessedBlockHash,
+          blockInfo.previousBlockHash
+        )
       }
     }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -50,6 +50,7 @@ export interface ActionHandler {
 export interface ActionHandlerOptions extends LogOptions {
   effectRunMode?: EffectRunMode
   maxEffectErrors?: number
+  validateBlockHashes?: boolean
 }
 
 export interface Block {


### PR DESCRIPTION
Some implementors of the `AbstractActionHandler` want to opt-out of validating block hash consistency, allowing the assumption to be made that the `ActionReader` is fulfilling its responsibility to do so. While potentially increasing the risk of uncaught determinism bugs, this has the advantage of allowing the implemented `ActionHandler` to skip irrelevant blocks.

This PR adds a configuration option `validateBlockHashes` to `ActionHandlerOptions` (defaulting to `true` for safety) that, when false, will skip the block validation step when processing new blocks.