### PR TITLE
Changed validateBlockHashes to validateBlocks

### DIFF
--- a/src/AbstractActionHandler.test.ts
+++ b/src/AbstractActionHandler.test.ts
@@ -134,7 +134,7 @@ describe('Action Handler', () => {
     )
     noHashValidationActionHandler = new TestActionHandler(
       handlerVersions,
-      { logLevel: 'error', validateBlockHashes: false }
+      { logLevel: 'error', validateBlocks: false }
     )
     noEffectActionHandler = new TestActionHandler(
       handlerVersions,
@@ -249,7 +249,7 @@ describe('Action Handler', () => {
     await expect(result).rejects.toThrow(MismatchedBlockHashError)
   })
 
-  it(`doesn't throw error if validateBlockHashes is false`, async () => {
+  it(`doesn't throw error if validateBlocks is false`, async () => {
     await noHashValidationActionHandler.initialize()
     noHashValidationActionHandler.setLastProcessedBlockNumber(3)
     noHashValidationActionHandler.setLastProcessedBlockHash('asdfasdfasdf')

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -103,8 +103,8 @@ export abstract class AbstractActionHandler implements ActionHandler {
       return nextBlockNeeded
     }
     // Only check if this is the block we need if it's not the first block
-    if (!isEarliestBlock) {
-      if (blockInfo.blockNumber !== nextBlockNeeded && this.validateBlocks) {
+    if (!isEarliestBlock && this.validateBlocks) {
+      if (blockInfo.blockNumber !== nextBlockNeeded) {
         this.log.debug(
           `Got block ${blockInfo.blockNumber} but block ${nextBlockNeeded} is needed; ` +
           `requesting block ${nextBlockNeeded}`
@@ -112,7 +112,7 @@ export abstract class AbstractActionHandler implements ActionHandler {
         return nextBlockNeeded
       }
       // Block sequence consistency should be handled by the ActionReader instance
-      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash && this.validateBlocks) {
+      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash) {
         throw new MismatchedBlockHashError(
           blockInfo.blockNumber,
           this.lastProcessedBlockHash,

--- a/src/AbstractActionHandler.ts
+++ b/src/AbstractActionHandler.ts
@@ -43,7 +43,7 @@ export abstract class AbstractActionHandler implements ActionHandler {
   private runningEffects: Array<QueryablePromise<void>> = []
   private effectErrors: string[] = []
   private maxEffectErrors: number
-  private validateBlockHashes: boolean
+  private validateBlocks: boolean
 
   /**
    * @param handlerVersions  An array of `HandlerVersion`s that are to be used when processing blocks. The default
@@ -60,14 +60,14 @@ export abstract class AbstractActionHandler implements ActionHandler {
       logSource: 'AbstractActionHandler',
       logLevel: 'info' as LogLevel,
       maxEffectErrors: 100,
-      validateBlockHashes: true,
+      validateBlocks: true,
       ...options,
     }
     this.initHandlerVersions(handlerVersions)
     this.effectRunMode = optionsWithDefaults.effectRunMode
     this.maxEffectErrors = optionsWithDefaults.maxEffectErrors
     this.log = BunyanProvider.getLogger(optionsWithDefaults)
-    this.validateBlockHashes = optionsWithDefaults.validateBlockHashes
+    this.validateBlocks = optionsWithDefaults.validateBlocks
   }
 
   /**
@@ -104,7 +104,7 @@ export abstract class AbstractActionHandler implements ActionHandler {
     }
     // Only check if this is the block we need if it's not the first block
     if (!isEarliestBlock) {
-      if (blockInfo.blockNumber !== nextBlockNeeded) {
+      if (blockInfo.blockNumber !== nextBlockNeeded && this.validateBlocks) {
         this.log.debug(
           `Got block ${blockInfo.blockNumber} but block ${nextBlockNeeded} is needed; ` +
           `requesting block ${nextBlockNeeded}`
@@ -112,7 +112,7 @@ export abstract class AbstractActionHandler implements ActionHandler {
         return nextBlockNeeded
       }
       // Block sequence consistency should be handled by the ActionReader instance
-      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash && this.validateBlockHashes) {
+      if (blockInfo.previousBlockHash !== this.lastProcessedBlockHash && this.validateBlocks) {
         throw new MismatchedBlockHashError(
           blockInfo.blockNumber,
           this.lastProcessedBlockHash,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -50,7 +50,7 @@ export interface ActionHandler {
 export interface ActionHandlerOptions extends LogOptions {
   effectRunMode?: EffectRunMode
   maxEffectErrors?: number
-  validateBlockHashes?: boolean
+  validateBlocks?: boolean
 }
 
 export interface Block {


### PR DESCRIPTION
As discussed on Telegram, I changed the validateBlockHashes option to validateBlocks, and it now fully skips block validation in the abstract action handler.